### PR TITLE
fix(backstage): Entity reference had missing kind

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -20,7 +20,7 @@ spec:
   providesApis:
     - carbonio-user-management-rest-api
   dependsOn:
-    - carbonio-mailbox
+    - component:carbonio-mailbox
 
 ---
 


### PR DESCRIPTION
Entity reference "carbonio-mailbox" had missing or empty kind (e.g. did not start with "component:" or similar)

More info: https://backstage.io/docs/features/software-catalog/descriptor-format#specdependson-optional

Example: https://github.com/Zextras/zextras-mobile/blob/main/catalog-info.yaml#L15-L25