### PR TITLE
feat: UM-13 add intentions for carbonio-tasks

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -64,7 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </exclusions>
       <groupId>com.zextras.carbonio.user-management</groupId>
 
-      <version>0.1.3-2</version>
+      <version>0.1.3-3</version>
     </dependency>
 
     <!-- Jetty dependencies -->
@@ -116,7 +116,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.1.3-2</version>
+    <version>0.1.3-3</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,24 +14,24 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.1.3-2</version>
+    <version>0.1.3-3</version>
   </parent>
 
   <artifactId>carbonio-user-management-core</artifactId>
   <name>carbonio-user-management-core</name>
-  <version>0.1.3-2</version>
+  <version>0.1.3-3</version>
 
   <dependencies>
     <dependency>
       <artifactId>carbonio-user-management-generated</artifactId>
       <groupId>com.zextras.carbonio.user-management</groupId>
-      <version>0.1.3-2</version>
+      <version>0.1.3-3</version>
     </dependency>
 
     <dependency>
       <artifactId>carbonio-soap-client</artifactId>
       <groupId>com.zextras.carbonio.soap-client</groupId>
-      <version>0.1.3-2</version>
+      <version>0.1.3-3</version>
     </dependency>
 
     <dependency>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -152,7 +152,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.1.3-2</version>
+    <version>0.1.3-3</version>
   </parent>
-  <version>0.1.3-2</version>
+  <version>0.1.3-3</version>
 </project>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-user-management"
 pkgver="0.1.3"
-pkgrel="2"
+pkgrel="3"
 pkgdesc="Carbonio User Management"
 pkgdesclong=(
   "Carbonio User Management"

--- a/package/intentions.json
+++ b/package/intentions.json
@@ -107,6 +107,29 @@
           }
         }
       ]
+    },
+    {
+      "Name": "carbonio-tasks",
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/auth/token/",
+            "Methods": [
+              "GET"
+            ]
+          }
+        },
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/health/",
+            "Methods": [
+              "GET"
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.1.3-2</version>
+  <version>0.1.3-3</version>
 
   <modules>
     <module>boot</module>

--- a/soapclient/pom.xml
+++ b/soapclient/pom.xml
@@ -60,5 +60,5 @@ SPDX-License-Identifier: AGPL-3.0-only
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <version>0.1.3-2</version>
+  <version>0.1.3-3</version>
 </project>


### PR DESCRIPTION
- Added intentions for carbonio-tasks: now it is allowed to use the following APIs:
  - /auth/token/
  - /health/

- Bumped jaxws-rt dependency to 2.3.2 due to a security issue