### PR TITLE
chore(infra): UM-15 - Update intentions.json aligning it to new chats naming

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,37 @@ pipeline {
                 }
             }
         }
+        stage('Upload To Develop') {
+            when {
+                branch 'develop'
+            }
+            steps {
+                unstash 'artifacts-deb'
+                unstash 'artifacts-rpm'
+                script {
+                    def server = Artifactory.server 'zextras-artifactory'
+                    def buildInfo
+                    def uploadSpec
+
+                    buildInfo = Artifactory.newBuildInfo()
+                    uploadSpec = '''{
+                        "files": [
+                            {
+                                "pattern": "artifacts/carbonio-user-management*.deb",
+                                "target": "ubuntu-develop/pool/",
+                                "props": "deb.distribution=bionic;deb.distribution=focal;deb.component=main;deb.architecture=amd64"
+                            },
+                            {
+                                "pattern": "artifacts/(carbonio-user-management)-(*).rpm",
+                                "target": "centos8-develop/zextras/{1}/{1}-{2}.rpm",
+                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras"
+                            }
+                        ]
+                    }'''
+                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
+                }
+            }
+        }
         stage('Upload To Playground') {
             when {
                 anyOf {

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -64,7 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </exclusions>
       <groupId>com.zextras.carbonio.user-management</groupId>
 
-      <version>0.2.1-1</version>
+      <version>0.2.1-2304131313</version>
     </dependency>
 
     <!-- Jetty dependencies -->
@@ -116,7 +116,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.1-1</version>
+    <version>0.2.1-2304131313</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,18 +14,18 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.1-1</version>
+    <version>0.2.1-2304131313</version>
   </parent>
 
   <artifactId>carbonio-user-management-core</artifactId>
   <name>carbonio-user-management-core</name>
-  <version>0.2.1-1</version>
+  <version>0.2.1-2304131313</version>
 
   <dependencies>
     <dependency>
       <artifactId>carbonio-user-management-generated</artifactId>
       <groupId>com.zextras.carbonio.user-management</groupId>
-      <version>0.2.1-1</version>
+      <version>0.2.1-2304131313</version>
     </dependency>
 
     <dependency>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -152,7 +152,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.1-1</version>
+    <version>0.2.1-2304131313</version>
   </parent>
-  <version>0.2.1-1</version>
+  <version>0.2.1-2304131313</version>
 </project>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-user-management"
 pkgver="0.2.1"
-pkgrel="1"
+pkgrel="2304131313"
 pkgdesc="Carbonio User Management"
 pkgdesclong=(
   "Carbonio User Management"

--- a/package/intentions.json
+++ b/package/intentions.json
@@ -56,7 +56,7 @@
       ]
     },
     {
-      "Name": "carbonio-chats",
+      "Name": "carbonio-ws-collaboration",
       "Permissions": [
         {
           "Action": "allow",
@@ -116,6 +116,29 @@
                 "Present": true
               }
             ],
+            "Methods": [
+              "GET"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "Name": "carbonio-message-dispatcher-auth",
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/auth/token/",
+            "Methods": [
+              "GET"
+            ]
+          }
+        },
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/health/",
             "Methods": [
               "GET"
             ]

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.2.1-1</version>
+  <version>0.2.1-2304131313</version>
 
   <modules>
     <module>boot</module>


### PR DESCRIPTION
- In intentions.json, the carbonio-chats entry is renamed to carbonio-ws-collaboration
- In intentions.json, the carbonio-message-dispatcher-auth is added enabling only the /auth/token/ API