### PR TITLE
chore(infra): UM-17 - Add intentions for carbonio-docs-connector

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -64,7 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       </exclusions>
       <groupId>com.zextras.carbonio.user-management</groupId>
 
-      <version>0.2.1-2304131313</version>
+      <version>0.2.1-2304211613</version>
     </dependency>
 
     <!-- Jetty dependencies -->
@@ -116,7 +116,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.1-2304131313</version>
+    <version>0.2.1-2304211613</version>
   </parent>
 
   <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,18 +14,18 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.1-2304131313</version>
+    <version>0.2.1-2304211613</version>
   </parent>
 
   <artifactId>carbonio-user-management-core</artifactId>
   <name>carbonio-user-management-core</name>
-  <version>0.2.1-2304131313</version>
+  <version>0.2.1-2304211613</version>
 
   <dependencies>
     <dependency>
       <artifactId>carbonio-user-management-generated</artifactId>
       <groupId>com.zextras.carbonio.user-management</groupId>
-      <version>0.2.1-2304131313</version>
+      <version>0.2.1-2304211613</version>
     </dependency>
 
     <dependency>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -152,7 +152,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <artifactId>carbonio-user-management</artifactId>
     <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.1-2304131313</version>
+    <version>0.2.1-2304211613</version>
   </parent>
-  <version>0.2.1-2304131313</version>
+  <version>0.2.1-2304211613</version>
 </project>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -8,7 +8,7 @@ targets=(
 )
 pkgname="carbonio-user-management"
 pkgver="0.2.1"
-pkgrel="2304131313"
+pkgrel="2304211613"
 pkgdesc="Carbonio User Management"
 pkgdesclong=(
   "Carbonio User Management"
@@ -18,7 +18,7 @@ arch="amd64"
 section="admin"
 priority="optional"
 url="https://www.zextras.com/"
-license=("spdx:AGPL-3.0-only")
+license=("AGPL-3.0-only")
 depends=(
   "service-discover"
   "pending-setups"

--- a/package/intentions.json
+++ b/package/intentions.json
@@ -168,6 +168,44 @@
           }
         }
       ]
+    },
+    {
+      "Name": "carbonio-docs-connector",
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/auth/token/",
+            "Methods": [
+              "GET"
+            ]
+          }
+        },
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/users/id/",
+            "Header": [
+              {
+                "Name": "Cookie",
+                "Present": true
+              }
+            ],
+            "Methods": [
+              "GET"
+            ]
+          }
+        },
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/health/",
+            "Methods": [
+              "GET"
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.2.1-2304131313</version>
+  <version>0.2.1-2304211613</version>
 
   <modules>
     <module>boot</module>


### PR DESCRIPTION
Added intentions for `carbonio-docs-connector`. Only the following APIs are enabled:
 - `/auth/token/`
 - `/users/id/`