### PR TITLE
chore(bump): UM-19 - Bump version of all dependencies and jdk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
 pipeline {
     agent {
         node {
-            label 'carbonio-agent-v2'
+            label 'openjdk17-agent-v1'
         }
     }
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
 pipeline {
     agent {
         node {
-            label 'openjdk11-agent-v1'
+            label 'openjdk17-agent-v1'
         }
     }
     environment {
@@ -105,12 +105,12 @@ pipeline {
                         "files": [
                             {
                                 "pattern": "artifacts/carbonio-user-management*.deb",
-                                "target": "ubuntu-develop/pool/",
+                                "target": "ubuntu-devel/pool/",
                                 "props": "deb.distribution=bionic;deb.distribution=focal;deb.component=main;deb.architecture=amd64"
                             },
                             {
                                 "pattern": "artifacts/(carbonio-user-management)-(*).rpm",
-                                "target": "centos8-develop/zextras/{1}/{1}-{2}.rpm",
+                                "target": "centos8-devel/zextras/{1}/{1}-{2}.rpm",
                                 "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras"
                             }
                         ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
 pipeline {
     agent {
         node {
-            label 'openjdk17-agent-v1'
+            label 'carbonio-agent-v2'
         }
     }
     environment {

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -22,7 +22,6 @@ SPDX-License-Identifier: AGPL-3.0-only
   </parent>
 
   <dependencies>
-
     <dependency>
       <groupId>com.zextras.carbonio.user-management</groupId>
       <artifactId>carbonio-user-management-core</artifactId>
@@ -67,7 +66,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>jaxrs-api</artifactId>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -110,5 +108,4 @@ SPDX-License-Identifier: AGPL-3.0-only
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,14 +25,14 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.2.4-1</version>
+    <version>0.2.5-SNAPSHOT</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>com.zextras.carbonio.user-management</groupId>
       <artifactId>carbonio-user-management-core</artifactId>
-      <version>0.2.4-1</version>
+      <version>0.2.5-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>javax.ws.rs</groupId>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -10,22 +10,83 @@ SPDX-License-Identifier: AGPL-3.0-only
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+  <modelVersion>4.0.0</modelVersion>
+
   <artifactId>carbonio-user-management-boot</artifactId>
+  <name>carbonio-user-management-boot</name>
+
+  <parent>
+    <groupId>com.zextras.carbonio.user-management</groupId>
+    <artifactId>carbonio-user-management</artifactId>
+    <version>0.2.4-1</version>
+  </parent>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.zextras.carbonio.user-management</groupId>
+      <artifactId>carbonio-user-management-core</artifactId>
+      <version>0.2.4-1</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>jsr311-api</artifactId>
+          <groupId>javax.ws.rs</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Jetty dependencies -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+
+    <!-- Guice dependencies -->
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
+
+    <!-- RestEasy dependencies -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-guice</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-servlet-initializer</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>jaxrs-api</artifactId>
+    </dependency>
+
+  </dependencies>
+
   <build>
-    <finalName>carbonio-user-management-${parent.version}</finalName>
+    <finalName>carbonio-user-management-${project.parent.version}</finalName>
 
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>11</source>
-          <target>11</target>
-        </configuration>
         <groupId>org.apache.maven.plugins</groupId>
-        <version>3.8.1</version>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>${maven-assembly-plugin.version}</version>
         <executions>
           <execution>
             <configuration>
@@ -46,82 +107,8 @@ SPDX-License-Identifier: AGPL-3.0-only
             <phase>package</phase>
           </execution>
         </executions>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3.0</version>
       </plugin>
     </plugins>
   </build>
-
-  <dependencies>
-
-    <dependency>
-      <artifactId>carbonio-user-management-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <artifactId>jsr311-api</artifactId>
-          <groupId>javax.ws.rs</groupId>
-        </exclusion>
-      </exclusions>
-      <groupId>com.zextras.carbonio.user-management</groupId>
-
-      <version>0.2.4-1</version>
-    </dependency>
-
-    <!-- Jetty dependencies -->
-    <dependency>
-      <artifactId>jetty-server</artifactId>
-      <groupId>org.eclipse.jetty</groupId>
-      <version>${jetty-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>jetty-servlet</artifactId>
-      <groupId>org.eclipse.jetty</groupId>
-      <version>${jetty-version}</version>
-    </dependency>
-
-    <!-- Guice dependencies -->
-    <dependency>
-      <artifactId>guice</artifactId>
-      <groupId>com.google.inject</groupId>
-      <version>${guice.version}</version>
-    </dependency>
-
-    <!-- RestEasy dependencies -->
-    <dependency>
-      <artifactId>resteasy-guice</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${resteasy-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>resteasy-servlet-initializer</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${resteasy-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>jaxrs-api</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${jaxrs-api.version}</version>
-    </dependency>
-
-  </dependencies>
-
-  <modelVersion>4.0.0</modelVersion>
-  <name>carbonio-user-management-boot</name>
-
-  <packaging>jar</packaging>
-
-  <parent>
-    <artifactId>carbonio-user-management</artifactId>
-    <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.4-1</version>
-  </parent>
-
-  <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-  </properties>
 
 </project>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -12,6 +12,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <modelVersion>4.0.0</modelVersion>
 
+  <licenses>
+    <license>
+      <comments>Copyright (C) 2022 Zextras, https://www.zextras.com</comments>
+      <name>AGPL-3.0-only</name>
+    </license>
+  </licenses>
+
   <artifactId>carbonio-user-management-boot</artifactId>
   <name>carbonio-user-management-boot</name>
 
@@ -28,10 +35,16 @@ SPDX-License-Identifier: AGPL-3.0-only
       <version>0.2.4-1</version>
       <exclusions>
         <exclusion>
-          <artifactId>jsr311-api</artifactId>
           <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- Guice dependencies -->
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
     </dependency>
 
     <!-- Jetty dependencies -->
@@ -43,12 +56,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-    </dependency>
-
-    <!-- Guice dependencies -->
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
     </dependency>
 
     <!-- RestEasy dependencies -->
@@ -81,6 +88,7 @@ SPDX-License-Identifier: AGPL-3.0-only
           <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,6 +10,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <modelVersion>4.0.0</modelVersion>
 
+  <licenses>
+    <license>
+      <comments>Copyright (C) 2022 Zextras, https://www.zextras.com</comments>
+      <name>AGPL-3.0-only</name>
+    </license>
+  </licenses>
+
   <artifactId>carbonio-user-management-core</artifactId>
   <name>carbonio-user-management-core</name>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,150 +9,95 @@ SPDX-License-Identifier: AGPL-3.0-only
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <packaging>jar</packaging>
-
-  <parent>
-    <artifactId>carbonio-user-management</artifactId>
-    <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.4-1</version>
-  </parent>
 
   <artifactId>carbonio-user-management-core</artifactId>
   <name>carbonio-user-management-core</name>
-  <version>0.2.4-1</version>
+
+  <parent>
+    <groupId>com.zextras.carbonio.user-management</groupId>
+    <artifactId>carbonio-user-management</artifactId>
+    <version>0.2.4-1</version>
+  </parent>
 
   <dependencies>
     <dependency>
-      <artifactId>carbonio-user-management-generated</artifactId>
       <groupId>com.zextras.carbonio.user-management</groupId>
-      <version>0.2.4-1</version>
+      <artifactId>carbonio-user-management-generated</artifactId>
+      <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <artifactId>carbonio-soap-client</artifactId>
       <groupId>com.zextras.carbonio.soap-client</groupId>
-      <version>0.2.4-1</version>
+      <artifactId>carbonio-soap-client</artifactId>
+      <version>0.2.4-SNAPSHOT</version>
     </dependency>
 
+    <!-- Guice dependencies -->
     <dependency>
-      <artifactId>guice</artifactId>
       <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
     </dependency>
 
     <dependency>
-      <artifactId>resteasy-guice</artifactId>
       <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-guice</artifactId>
     </dependency>
 
+    <!-- JavaEE API -->
     <dependency>
-      <artifactId>javaee-api</artifactId>
       <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
       <scope>provided</scope>
     </dependency>
 
+    <!-- RestEasy dependencies -->
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-core</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
       <artifactId>jaxrs-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-validator-provider</artifactId>
     </dependency>
 
     <dependency>
-      <artifactId>resteasy-multipart-provider</artifactId>
       <groupId>org.jboss.resteasy</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>resteasy-validator-provider-11</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>resteasy-jackson2-provider</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>swagger-annotations</artifactId>
-      <groupId>io.swagger</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>swagger-jaxrs</artifactId>
-      <groupId>io.swagger</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>javax.annotation-api</artifactId>
-      <groupId>javax.annotation</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>jackson-databind</artifactId>
-      <groupId>com.fasterxml.jackson.core</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>jackson-core</artifactId>
-      <groupId>com.fasterxml.jackson.core</groupId>
-    </dependency>
-
-    <dependency>
       <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+    </dependency>
+
+    <!-- Jackson dependencies -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
 
     <dependency>
-      <artifactId>jackson-datatype-joda</artifactId>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
 
     <dependency>
-      <artifactId>joda-time</artifactId>
-      <groupId>joda-time</groupId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
 
+    <!-- Cache -->
     <dependency>
-      <artifactId>caffeine</artifactId>
       <groupId>com.github.ben-manes.caffeine</groupId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
+      <artifactId>caffeine</artifactId>
     </dependency>
 
   </dependencies>
-
-  <build>
-    <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <parallel>classes</parallel>
-        </configuration>
-      </plugin>
-
-    </plugins>
-    <sourceDirectory>src/main/java</sourceDirectory>
-  </build>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.2.4-1</version>
+    <version>0.2.5-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -97,7 +97,5 @@ SPDX-License-Identifier: AGPL-3.0-only
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>
-
   </dependencies>
-
 </project>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -7,152 +7,105 @@ SPDX-License-Identifier: AGPL-3.0-only
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <artifactId>carbonio-user-management-generated</artifactId>
+  <name>carbonio-user-management-generated</name>
+
+  <parent>
+    <groupId>com.zextras.carbonio.user-management</groupId>
+    <artifactId>carbonio-user-management</artifactId>
+    <version>0.2.4-1</version>
+  </parent>
+
+  <dependencies>
+
+    <!-- JavaEE API -->
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- RESTEasy dependencies -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>jaxrs-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-validator-provider</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxb-provider</artifactId>
+    </dependency>
+
+    <!-- Jackson dependencies -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <!-- Swagger annotation dependencies -->
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+    </dependency>
+
+  </dependencies>
+
   <build>
     <plugins>
+      <!-- Triggers the generator during the package build -->
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>11</source>
-          <target>11</target>
-        </configuration>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.6.1</version>
-      </plugin>
-      <plugin>
-        <artifactId>openapi-generator-maven-plugin</artifactId>
         <groupId>org.openapitools</groupId>
+        <artifactId>openapi-generator-maven-plugin</artifactId>
       </plugin>
+
       <plugin>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <configuration>
-              <sources>
-                <source>
-                  src/gen/java
-                </source>
-              </sources>
-            </configuration>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-          </execution>
-        </executions>
         <groupId>org.codehaus.mojo</groupId>
-        <version>1.9.1</version>
+        <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
     </plugins>
     <sourceDirectory>src/main/java</sourceDirectory>
   </build>
-  <dependencies>
 
-    <dependency>
-      <artifactId>javaee-api</artifactId>
-      <groupId>javax</groupId>
-      <scope>provided</scope>
-      <version>${javaee-api.version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>jackson-databind</artifactId>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <version>2.13.0</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>jackson-core</artifactId>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <version>2.13.0</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>jackson-annotations</artifactId>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <version>2.13.0</version>
-    </dependency>
-    <dependency>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <version>2.11.3</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>resteasy-jaxb-provider</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${resteasy-version}</version>
-    </dependency>
-    <dependency>
-      <artifactId>resteasy-core</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${resteasy-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>jaxrs-api</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${jaxrs-api.version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>resteasy-multipart-provider</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${resteasy-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>resteasy-validator-provider-11</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${resteasy-validator.version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>resteasy-jackson2-provider</artifactId>
-      <groupId>org.jboss.resteasy</groupId>
-      <version>${resteasy-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>swagger-annotations</artifactId>
-      <groupId>io.swagger</groupId>
-      <version>${swagger-core-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>swagger-jaxrs</artifactId>
-      <groupId>io.swagger</groupId>
-      <version>${swagger-core-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>javax.annotation-api</artifactId>
-      <groupId>javax.annotation</groupId>
-      <version>${javax-annotation-api.version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>jackson-datatype-joda</artifactId>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <version>${jackson-version}</version>
-    </dependency>
-
-    <dependency>
-      <artifactId>joda-time</artifactId>
-      <groupId>joda-time</groupId>
-      <version>${joda-time.version}</version>
-    </dependency>
-
-  </dependencies>
-  <modelVersion>4.0.0</modelVersion>
-  <name>carbonio-user-management-generated</name>
-
-  <packaging>jar</packaging>
-  <parent>
-    <artifactId>carbonio-user-management</artifactId>
-    <groupId>com.zextras.carbonio.user-management</groupId>
-    <version>0.2.4-1</version>
-  </parent>
-  <version>0.2.4-1</version>
 </project>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -7,6 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>carbonio-user-management-generated</artifactId>
@@ -19,7 +20,6 @@ SPDX-License-Identifier: AGPL-3.0-only
   </parent>
 
   <dependencies>
-
     <!-- JavaEE API -->
     <dependency>
       <groupId>javax</groupId>
@@ -89,7 +89,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -107,5 +106,4 @@ SPDX-License-Identifier: AGPL-3.0-only
     </plugins>
     <sourceDirectory>src/main/java</sourceDirectory>
   </build>
-
 </project>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.2.4-1</version>
+    <version>0.2.5-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -7,8 +7,8 @@ targets=(
   "centos"
 )
 pkgname="carbonio-user-management"
-pkgver="0.2.4"
-pkgrel="1"
+pkgver="0.2.5"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio User Management"
 pkgdesclong=(
   "Carbonio User Management"

--- a/package/carbonio-user-management.service
+++ b/package/carbonio-user-management.service
@@ -25,3 +25,4 @@ TimeoutStopSec=120
 
 [Install]
 WantedBy=multi-user.target
+java -Djava.net.preferIPv4Stack=true -Xmx1024m -Xms1024m -jar ./boot/target/carbonio-user-management

--- a/package/carbonio-user-management.service
+++ b/package/carbonio-user-management.service
@@ -25,4 +25,3 @@ TimeoutStopSec=120
 
 [Install]
 WantedBy=multi-user.target
-java -Djava.net.preferIPv4Stack=true -Xmx1024m -Xms1024m -jar ./boot/target/carbonio-user-management

--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,22 @@ SPDX-License-Identifier: AGPL-3.0-only
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-  <name>carbonio-user-management</name>
-
   <modelVersion>4.0.0</modelVersion>
-  <packaging>pom</packaging>
+
+  <licenses>
+    <license>
+      <comments>Copyright (C) 2022 Zextras, https://www.zextras.com</comments>
+      <name>AGPL-3.0-only</name>
+    </license>
+  </licenses>
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
   <version>0.2.4-1</version>
+  <packaging>pom</packaging>
+
+  <name>carbonio-user-management</name>
+  <url>https://www.github.com/Zextras/carbonio-user-management</url>
 
   <modules>
     <module>boot</module>
@@ -30,7 +38,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <caffeine.version>3.1.6</caffeine.version>
     <guice.version>6.0.0</guice.version>
     <jackson.version>2.15.2</jackson.version>
-    <javaee-api.version>7.0</javaee-api.version>
+    <javaee-api.version>8.0.1</javaee-api.version>
     <jetty-version>10.0.15</jetty-version>
     <resteasy-jaxrs-api.version>3.0.12.Final</resteasy-jaxrs-api.version>
     <resteasy.version>4.7.9.Final</resteasy.version>
@@ -55,19 +63,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <dependencyManagement>
     <dependencies>
-      <!-- Jetty dependencies -->
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${jetty-version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
-        <version>${jetty-version}</version>
-      </dependency>
-
       <!-- Guice dependencies -->
       <dependency>
         <groupId>com.google.inject</groupId>
@@ -79,6 +74,19 @@ SPDX-License-Identifier: AGPL-3.0-only
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-guice</artifactId>
         <version>${resteasy.version}</version>
+      </dependency>
+
+      <!-- Jetty dependencies -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${jetty-version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlet</artifactId>
+        <version>${jetty-version}</version>
       </dependency>
 
       <!-- JavaEE API -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.2.4-1</version>
+  <version>0.2.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-user-management</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,237 +27,168 @@ SPDX-License-Identifier: AGPL-3.0-only
   </modules>
 
   <properties>
-    <com.fasterxml.jackson.jaxrs.version>2.11.3</com.fasterxml.jackson.jaxrs.version>
-    <com.fasterxml.jackson.version>2.13.0</com.fasterxml.jackson.version>
-    <com.github.ben-manes.caffeine.version>3.0.5</com.github.ben-manes.caffeine.version>
-    <guice.version>5.0.1</guice.version>
-    <io.ebean.version>12.12.3</io.ebean.version>
-    <io.vavr.version>1.0.0-alpha-4</io.vavr.version>
-    <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
-    <jackson-databind-version>2.10.5.1</jackson-databind-version>
-    <jackson-version>2.11.2</jackson-version>
-    <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+    <caffeine.version>3.1.6</caffeine.version>
+    <guice.version>6.0.0</guice.version>
+    <jackson.version>2.15.2</jackson.version>
     <javaee-api.version>7.0</javaee-api.version>
-    <javax-annotation-api.version>1.2</javax-annotation-api.version>
-    <javax-validation-api.version>1.1.0.Final</javax-validation-api.version>
-    <jaxrs-api.version>3.0.12.Final</jaxrs-api.version>
-    <jaxws-rt.version>2.3.2</jaxws-rt.version>
-    <jaxb-impl.version>2.3.1</jaxb-impl.version>
-    <jetty-version>10.0.6</jetty-version>
-    <joda-time.version>2.7</joda-time.version>
-    <junit-version>4.13</junit-version>
-    <junit-version>4.13.1</junit-version>
-    <maven-plugin-version>1.0.0</maven-plugin-version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <org.junit.jupiter.version>5.8.2</org.junit.jupiter.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <resolver.version>20050927</resolver.version>
-    <resteasy-jaxrs-version>2.2.1.GA</resteasy-jaxrs-version>
-    <resteasy-validator.version>3.6.3.SP1</resteasy-validator.version>
-    <resteasy-version>4.7.2.Final</resteasy-version>
-    <resteasy2-version>3.13.0.Final</resteasy2-version>
-    <servlet-api-version>2.5</servlet-api-version>
-    <slf4j-version>1.6.3</slf4j-version>
-    <swagger-annotations-version>1.5.22</swagger-annotations-version>
-    <swagger-core-version>1.5.22</swagger-core-version>
-    <threetenbp-version>2.9.10</threetenbp-version>
-    <org.mockito.version>4.3.0</org.mockito.version>
+    <jetty-version>10.0.15</jetty-version>
+    <resteasy-jaxrs-api.version>3.0.12.Final</resteasy-jaxrs-api.version>
+    <resteasy.version>4.7.9.Final</resteasy.version>
+    <swagger-core-version>1.6.11</swagger-core-version>
+    <!-- We are using an alpha package due to some vulnerabilities of the stable one -->
+    <vavr.version>1.0.0-alpha-4</vavr.version>
 
     <!-- Plugins -->
-    <ebean-maven-plugin.version>13.6.5</ebean-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
+    <jaxws-maven-plugin.version>2.6</jaxws-maven-plugin.version>
+    <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+    <openapi-generator-maven-plugin.version>6.6.0</openapi-generator-maven-plugin.version>
+
+    <!-- Other properties -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-
+      <!-- Jetty dependencies -->
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <groupId>org.eclipse.jetty</groupId>
         <version>${jetty-version}</version>
       </dependency>
 
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <groupId>org.eclipse.jetty</groupId>
         <version>${jetty-version}</version>
       </dependency>
 
+      <!-- Guice dependencies -->
       <dependency>
-        <artifactId>jaxws-rt</artifactId>
-        <groupId>com.sun.xml.ws</groupId>
-        <version>${jaxws-rt.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>jaxb-impl</artifactId>
-        <groupId>com.sun.xml.bind</groupId>
-        <version>${jaxb-impl.version}</version>
-      </dependency>
-
-      <!-- Dependency necessary to resolve NoClassDefFound of com/sun/org/apache/xml/internal/resolver/CatalogManager -->
-      <dependency>
-        <artifactId>resolver</artifactId>
-        <groupId>com.sun.org.apache.xml.internal</groupId>
-        <version>${resolver.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>javaee-api</artifactId>
-        <groupId>javax</groupId>
-        <scope>provided</scope>
-        <version>${javaee-api.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>resteasy-core</artifactId>
-        <groupId>org.jboss.resteasy</groupId>
-        <version>${resteasy-version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>jaxrs-api</artifactId>
-        <groupId>org.jboss.resteasy</groupId>
-        <version>${jaxrs-api.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>resteasy-multipart-provider</artifactId>
-        <groupId>org.jboss.resteasy</groupId>
-        <version>${resteasy-version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>resteasy-validator-provider-11</artifactId>
-        <groupId>org.jboss.resteasy</groupId>
-        <version>${resteasy-validator.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>resteasy-jackson2-provider</artifactId>
-        <groupId>org.jboss.resteasy</groupId>
-        <version>${resteasy-version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>resteasy-jaxb-provider</artifactId>
-        <groupId>org.jboss.resteasy</groupId>
-        <version>${resteasy-version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>jackson-databind</artifactId>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <version>${com.fasterxml.jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>jackson-core</artifactId>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <version>${com.fasterxml.jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>jackson-annotations</artifactId>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <version>${com.fasterxml.jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <version>${com.fasterxml.jackson.jaxrs.version}</version>
-      </dependency>
-
-      <dependency>
-        <artifactId>guice</artifactId>
         <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
         <version>${guice.version}</version>
       </dependency>
 
       <dependency>
-        <artifactId>resteasy-guice</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>${resteasy-version}</version>
+        <artifactId>resteasy-guice</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+
+      <!-- JavaEE API -->
+      <dependency>
+        <groupId>javax</groupId>
+        <artifactId>javaee-api</artifactId>
+        <version>${javaee-api.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <!-- RESTEasy dependencies -->
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-core</artifactId>
+        <version>${resteasy.version}</version>
       </dependency>
 
       <dependency>
-        <artifactId>swagger-annotations</artifactId>
-        <groupId>io.swagger</groupId>
-        <version>${swagger-core-version}</version>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-servlet-initializer</artifactId>
+        <version>${resteasy.version}</version>
       </dependency>
 
       <dependency>
-        <artifactId>swagger-jaxrs</artifactId>
-        <groupId>io.swagger</groupId>
-        <version>${swagger-core-version}</version>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>jaxrs-api</artifactId>
+        <version>${resteasy-jaxrs-api.version}</version>
       </dependency>
 
       <dependency>
-        <artifactId>javax.annotation-api</artifactId>
-        <groupId>javax.annotation</groupId>
-        <version>${javax-annotation-api.version}</version>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-validator-provider</artifactId>
+        <version>${resteasy.version}</version>
       </dependency>
 
       <dependency>
-        <artifactId>jackson-datatype-joda</artifactId>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jackson2-provider</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jaxb-provider</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+
+      <!-- Jackson dependencies -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
-        <version>${jackson-version}</version>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <!-- Swagger dependencies -->
+      <dependency>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>${swagger-core-version}</version>
       </dependency>
 
       <dependency>
-        <artifactId>joda-time</artifactId>
-        <groupId>joda-time</groupId>
-        <version>${joda-time.version}</version>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-jaxrs</artifactId>
+        <version>${swagger-core-version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
-      <!-- We are using an alpha package due to some vulnerabilities of the stable one -->
+      <!-- Vavr -->
       <dependency>
-        <artifactId>vavr</artifactId>
         <groupId>io.vavr</groupId>
-        <version>${io.vavr.version}</version>
+        <artifactId>vavr</artifactId>
+        <version>${vavr.version}</version>
       </dependency>
 
+      <!-- Cache -->
       <dependency>
-        <artifactId>caffeine</artifactId>
         <groupId>com.github.ben-manes.caffeine</groupId>
-        <version>${com.github.ben-manes.caffeine.version}</version>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>io.ebean</groupId>
-        <artifactId>ebean</artifactId>
-        <version>${io.ebean.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.ebean</groupId>
-        <artifactId>ebean-test</artifactId>
-        <version>${io.ebean.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${org.mockito.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
-        <version>${org.mockito.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${org.junit.jupiter.version}</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 
@@ -265,7 +196,9 @@ SPDX-License-Identifier: AGPL-3.0-only
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
           <artifactId>jaxws-maven-plugin</artifactId>
+          <version>${jaxws-maven-plugin.version}</version>
           <configuration>
             <args>
               <arg>-B-XautoNameResolution</arg>
@@ -281,31 +214,32 @@ SPDX-License-Identifier: AGPL-3.0-only
               </goals>
             </execution>
           </executions>
-          <groupId>org.codehaus.mojo</groupId>
-          <version>2.6</version>
         </plugin>
+
         <plugin>
+          <groupId>org.openapitools</groupId>
           <artifactId>openapi-generator-maven-plugin</artifactId>
+          <version>${openapi-generator-maven-plugin.version}</version>
           <executions>
             <execution>
               <configuration>
-                <apiPackage>com.zextras.carbonio.user_management.generated</apiPackage>
+                <generatorName>jaxrs-resteasy</generatorName>
+                <groupId>com.zextras.carbonio.user_management</groupId>
                 <artifactId>carbonio-user-management-generated</artifactId>
-                <artifactVersion>0.2.0</artifactVersion>
+                <apiPackage>com.zextras.carbonio.user_management.generated</apiPackage>
+                <packageName>com.zextras.carbonio.user_management</packageName>
+                <modelPackage>com.zextras.carbonio.user_management.generated.model</modelPackage>
                 <configOptions>
                   <artifactDescription>User Management generated</artifactDescription>
                   <librart>resteasy</librart>
                   <serializationLibrary>jackson</serializationLibrary>
+                  <dateLibrary>java8</dateLibrary>
                 </configOptions>
                 <generateApiTests>false</generateApiTests>
-                <generatorName>jaxrs-resteasy</generatorName>
-                <groupId>com.zextras.carbonio.user_management</groupId>
                 <inputSpec>
                   resources/user-management.yaml
                 </inputSpec>
-                <modelPackage>com.zextras.carbonio.user_management.generated.model</modelPackage>
                 <output>./</output>
-                <packageName>com.zextras.carbonio.user_management</packageName>
               </configuration>
               <goals>
                 <goal>generate</goal>
@@ -315,14 +249,7 @@ SPDX-License-Identifier: AGPL-3.0-only
               </phase>
             </execution>
           </executions>
-          <groupId>org.openapitools</groupId>
-          <version>5.2.1</version>
         </plugin>
-        <!--<plugin>
-          <groupId>io.ebean</groupId>
-          <artifactId>ebean-maven-plugin</artifactId>
-          <version>${ebean-maven-plugin.version}</version>
-        </plugin>-->
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -337,18 +264,27 @@ SPDX-License-Identifier: AGPL-3.0-only
         </plugin>
 
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven-surefire-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <configuration>
+                <sources>
+                  <source>
+                    src/gen/java
+                  </source>
+                </sources>
+              </configuration>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <id>add-source</id>
+              <phase>generate-sources</phase>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
   </build>
-
 </project>

--- a/soapclient/pom.xml
+++ b/soapclient/pom.xml
@@ -19,12 +19,12 @@ SPDX-License-Identifier: AGPL-3.0-only
   <name>carbonio-soap-client</name>
 
   <properties>
+    <jaxb-impl.version>4.0.3</jaxb-impl.version>
+    <jaxb-runtime.version>2.3.8</jaxb-runtime.version>
     <!--
       This is the newest version to use since the latest version of jaxws-maven-plugin generates
       imports with javax instead of jakarta. Don't bump it!
     -->
-    <jaxb-impl.version>4.0.3</jaxb-impl.version>
-    <jaxb-runtime.version>2.3.8</jaxb-runtime.version>
     <jaxws-rt.version>2.3.6</jaxws-rt.version>
     <no-class-def-found-resolver.version>20050927</no-class-def-found-resolver.version>
 

--- a/soapclient/pom.xml
+++ b/soapclient/pom.xml
@@ -9,56 +9,69 @@ SPDX-License-Identifier: AGPL-3.0-only
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <artifactId>carbonio-soap-client</artifactId>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>jaxws-maven-plugin</artifactId>
-        <groupId>org.codehaus.mojo</groupId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>11</source>
-          <target>11</target>
-        </configuration>
-        <groupId>org.apache.maven.plugins</groupId>
-      </plugin>
-    </plugins>
-  </build>
-  <dependencies>
-    <dependency>
-      <artifactId>junit</artifactId>
-      <groupId>junit</groupId>
-      <scope>test</scope>
-      <version>4.11</version>
-    </dependency>
-    <dependency>
-      <artifactId>jaxws-rt</artifactId>
-      <groupId>com.sun.xml.ws</groupId>
-      <version>2.3.2</version>
-    </dependency>
-    <dependency>
-      <artifactId>jaxb-impl</artifactId>
-      <groupId>com.sun.xml.bind</groupId>
-      <version>2.3.1</version>
-    </dependency>
-    <!-- Dependency necessary to resolve NoClassDefFound of com/sun/org/apache/xml/internal/resolver/CatalogManager -->
-    <dependency>
-      <artifactId>resolver</artifactId>
-      <groupId>com.sun.org.apache.xml.internal</groupId>
-      <version>20050927</version>
-    </dependency>
-  </dependencies>
-  <groupId>com.zextras.carbonio.soap-client</groupId>
   <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.zextras.carbonio.soap-client</groupId>
+  <artifactId>carbonio-soap-client</artifactId>
+  <version>0.2.4-SNAPSHOT</version>
 
   <name>carbonio-soap-client</name>
 
   <properties>
+    <!--
+      This is the newest version to use since the latest version of jaxws-maven-plugin generates
+      imports with javax instead of jakarta. Don't bump it!
+    -->
+    <jaxb-impl.version>4.0.3</jaxb-impl.version>
+    <jaxb-runtime.version>2.3.8</jaxb-runtime.version>
+    <jaxws-rt.version>2.3.6</jaxws-rt.version>
+    <no-class-def-found-resolver.version>20050927</no-class-def-found-resolver.version>
+
+    <!-- Other properties -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <version>0.2.4-1</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.sun.xml.ws</groupId>
+      <artifactId>jaxws-rt</artifactId>
+      <version>${jaxws-rt.version}</version>
+      <!--
+        The jaxb-runtime version included on jaxws-rt uses reflection, and it is not compatible
+        with the latest version of the JDK.
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>${jaxb-impl.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>${jaxb-runtime.version}</version>
+    </dependency>
+
+    <!--
+      Dependency necessary to resolve runtime NoClassDefFound of
+      com/sun/org/apache/xml/internal/resolver/CatalogManager
+    -->
+    <dependency>
+      <groupId>com.sun.org.apache.xml.internal</groupId>
+      <artifactId>resolver</artifactId>
+      <version>${no-class-def-found-resolver.version}</version>
+    </dependency>
+
+  </dependencies>
 </project>


### PR DESCRIPTION
- Updated all the dependencies to the latest version to resolve security issues (when possibile)
- Built the project with the openjdk version 17.0.7
- Cleaned up the poms
- Updated Jenkinsfile adding a step to replace the SNAPSHOT keyword with the hash of the commit when the artifacts are uploaded on develop repositories: it ensure that each merged PR has unique artifacts and prevents conflicts between them. Note that the pkgrel value will remain as SNAPSHOT in the codebase to avoid conflicts between multiple open PRs.
