### PR TITLE
feat: UM-20 - Implement /users/myself API to expose the user locale prefs

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,41 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: carbonio-user-management
+Upstream-Contact: Zextras <packages@zextras.com>
+Source: https://github.com/Zextras/carbonio-user-management
+
+Files: pacur.json
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+
+Files: package/intentions.json
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+
+Files: package/policies.json
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+
+Files: package/service-protocol.json
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+
+Files: core/src/test/resources/soap/requests/GetAccountInfoRequest.xml
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+
+Files: core/src/test/resources/soap/requests/GetInfoRequest.xml
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+
+Files: core/src/test/resources/soap/responses/GetAccountInfoResponse.xml
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+
+Files: core/src/test/resources/soap/responses/GetInfoResponse.xml
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+
+Files: core/src/test/resources/soap/responses/SoapNotFoundError.xml
+Copyright: 2023 Zextras s.r.l
+License: AGPL-3.0-only
+

--- a/boot/src/main/resources/logback.xml
+++ b/boot/src/main/resources/logback.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>/var/log/carbonio/user-management/user-management.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- daily rollover -->
+      <fileNamePattern>/var/log/carbonio/user-management/user-management.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <!-- each file should be at most 10MB-->
+      <maxFileSize>10MB</maxFileSize>
+      <!-- keep 50 days' worth of history -->
+      <maxHistory>50</maxHistory>
+      <!-- Keep at maximum 500MB of logs -->
+      <totalSizeCap>500MB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="ROLLING"/>
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>

--- a/core/src/main/java/com/zextras/carbonio/user_management/config/UserManagementModule.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/config/UserManagementModule.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.zextras.carbonio.user_management.controllers.AuthApiController;
 import com.zextras.carbonio.user_management.controllers.HealthApiController;
 import com.zextras.carbonio.user_management.controllers.UsersApiController;
+import com.zextras.carbonio.user_management.exceptions.ServiceExceptionMapper;
 import com.zextras.carbonio.user_management.generated.AuthApi;
 import com.zextras.carbonio.user_management.generated.AuthApiService;
 import com.zextras.carbonio.user_management.generated.HealthApi;
@@ -22,6 +23,7 @@ public class UserManagementModule extends RequestScopeModule {
   @Override
   protected void configure() {
     bind(JacksonJsonProvider.class);
+    bind(ServiceExceptionMapper.class);
 
     bind(HealthApi.class);
     bind(HealthApiService.class).to(HealthApiController.class);

--- a/core/src/main/java/com/zextras/carbonio/user_management/controllers/UsersApiController.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/controllers/UsersApiController.java
@@ -64,13 +64,13 @@ public class UsersApiController implements UsersApiService {
   }
 
   @Override
-  public Response getUserInfoByCookie(String cookie, SecurityContext securityContext) {
+  public Response getMyselfByCookie(String cookie, SecurityContext securityContext) {
     Map<String, String> cookies = CookieParser.getCookies(cookie);
 
     if (cookies.containsKey("ZM_AUTH_TOKEN")) {
       return userService
         .getInfoByToken(cookies.get("ZM_AUTH_TOKEN"))
-        .map(userInfo -> Response.ok().entity(userInfo).build())
+        .map(userMyself -> Response.ok().entity(userMyself).build())
         .orElse(Response.status(Status.NOT_FOUND).build());
     }
 

--- a/core/src/main/java/com/zextras/carbonio/user_management/controllers/UsersApiController.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/controllers/UsersApiController.java
@@ -5,7 +5,6 @@
 package com.zextras.carbonio.user_management.controllers;
 
 import com.google.inject.Inject;
-import com.zextras.carbonio.user_management.exceptions.ServiceException;
 import com.zextras.carbonio.user_management.generated.NotFoundException;
 import com.zextras.carbonio.user_management.generated.UsersApiService;
 import com.zextras.carbonio.user_management.services.UserService;
@@ -69,7 +68,7 @@ public class UsersApiController implements UsersApiService {
 
     if (cookies.containsKey("ZM_AUTH_TOKEN")) {
       return userService
-        .getInfoByToken(cookies.get("ZM_AUTH_TOKEN"))
+        .getMyselfByToken(cookies.get("ZM_AUTH_TOKEN"))
         .map(userMyself -> Response.ok().entity(userMyself).build())
         .orElse(Response.status(Status.NOT_FOUND).build());
     }

--- a/core/src/main/java/com/zextras/carbonio/user_management/controllers/UsersApiController.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/controllers/UsersApiController.java
@@ -5,6 +5,7 @@
 package com.zextras.carbonio.user_management.controllers;
 
 import com.google.inject.Inject;
+import com.zextras.carbonio.user_management.exceptions.ServiceException;
 import com.zextras.carbonio.user_management.generated.NotFoundException;
 import com.zextras.carbonio.user_management.generated.UsersApiService;
 import com.zextras.carbonio.user_management.services.UserService;
@@ -62,4 +63,17 @@ public class UsersApiController implements UsersApiService {
       : Response.status(Status.BAD_REQUEST).build();
   }
 
+  @Override
+  public Response getUserInfoByCookie(String cookie, SecurityContext securityContext) {
+    Map<String, String> cookies = CookieParser.getCookies(cookie);
+
+    if (cookies.containsKey("ZM_AUTH_TOKEN")) {
+      return userService
+        .getInfoByToken(cookies.get("ZM_AUTH_TOKEN"))
+        .map(userInfo -> Response.ok().entity(userInfo).build())
+        .orElse(Response.status(Status.NOT_FOUND).build());
+    }
+
+    return Response.status(Status.BAD_REQUEST).build();
+  }
 }

--- a/core/src/main/java/com/zextras/carbonio/user_management/exceptions/ServiceException.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/exceptions/ServiceException.java
@@ -1,5 +1,13 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package com.zextras.carbonio.user_management.exceptions;
 
+/**
+ * Exception to be used when something bad happen during the execution of a request or when a
+ * dependency (like the carbonio-mailbox) responds with an unexpected/unhandled error.
+ */
 public class ServiceException extends RuntimeException {
 
   public ServiceException(String message) {

--- a/core/src/main/java/com/zextras/carbonio/user_management/exceptions/ServiceException.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/exceptions/ServiceException.java
@@ -1,0 +1,12 @@
+package com.zextras.carbonio.user_management.exceptions;
+
+public class ServiceException extends RuntimeException {
+
+  public ServiceException(String message) {
+    super(message);
+  }
+
+  public ServiceException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/user_management/exceptions/ServiceExceptionMapper.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/exceptions/ServiceExceptionMapper.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package com.zextras.carbonio.user_management.exceptions;
 
 import javax.ws.rs.core.Response;

--- a/core/src/main/java/com/zextras/carbonio/user_management/exceptions/ServiceExceptionMapper.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/exceptions/ServiceExceptionMapper.java
@@ -1,0 +1,19 @@
+package com.zextras.carbonio.user_management.exceptions;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Maps the {@link ServiceException} exception into a jax-rs {@link Response} with an
+ * {@link Status#INTERNAL_SERVER_ERROR} status code.
+ */
+@Provider
+public class ServiceExceptionMapper implements ExceptionMapper<ServiceException> {
+
+  @Override
+  public Response toResponse(ServiceException exception) {
+    return Response.status(Status.INTERNAL_SERVER_ERROR).entity(exception.getMessage()).build();
+  }
+}

--- a/core/src/main/java/com/zextras/carbonio/user_management/services/UserService.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/services/UserService.java
@@ -13,6 +13,7 @@ import com.zextras.carbonio.user_management.exceptions.ServiceException;
 import com.zextras.carbonio.user_management.generated.model.Locale;
 import com.zextras.carbonio.user_management.generated.model.UserId;
 import com.zextras.carbonio.user_management.generated.model.UserInfo;
+import com.zextras.carbonio.user_management.generated.model.UserMyself;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -140,7 +141,7 @@ public class UserService {
     return Response.ok().entity(userInfo).build();
   }
 
-  public Optional<UserInfo> getInfoByToken(String token) {
+  public Optional<UserMyself> getInfoByToken(String token) {
     try {
       GetInfoResponse infoResponse = SoapClient
         .newClient()
@@ -159,13 +160,13 @@ public class UserService {
         .map(Pref::getValue)
         .orElse("en");
 
-      UserInfo userInfo = new UserInfo();
-      userInfo.setId(userId);
-      userInfo.setEmail(infoResponse.getName());
-      userInfo.setDomain(infoResponse.getPublicURL());
-      userInfo.setLocale(Locale.valueOf(locale.toUpperCase()));
+      UserMyself userMyself = new UserMyself();
+      userMyself.setId(userId);
+      userMyself.setEmail(infoResponse.getName());
+      userMyself.setDomain(infoResponse.getPublicURL());
+      userMyself.setLocale(Locale.valueOf(locale.toUpperCase()));
 
-      return Optional.of(userInfo);
+      return Optional.of(userMyself);
 
     } catch (ServerSOAPFaultException exception) {
       System.out.println(exception.getMessage());

--- a/core/src/test/java-it/com/zextras/carbonio/user_management/Simulator.java
+++ b/core/src/test/java-it/com/zextras/carbonio/user_management/Simulator.java
@@ -110,6 +110,10 @@ public final class Simulator implements AutoCloseable {
     return this;
   }
 
+  public void resetAll() {
+    mailboxServiceMock.reset();
+  }
+
   public void stopAll() {
     stopJettyServer();
     stopMailboxService();

--- a/core/src/test/java-it/com/zextras/carbonio/user_management/SoapHttpUtils.java
+++ b/core/src/test/java-it/com/zextras/carbonio/user_management/SoapHttpUtils.java
@@ -16,6 +16,15 @@ import org.apache.commons.io.IOUtils;
 public class SoapHttpUtils {
 
   /**
+   * Creates the SoapNotFoundError XML body.
+   *
+   * @return a {@link String} representing the XML body response containing the NotFound error.
+   */
+  public String getSoapNotFoundErrorResponse() {
+    return getXmlFile("soap/responses/SoapNotFoundError.xml");
+  }
+
+  /**
    * Creates the GetAccountInfoRequest XML body substituting the auth token and the account id in
    * the related placeholders.
    *
@@ -24,9 +33,9 @@ public class SoapHttpUtils {
    * @return a {@link String} representing the XML body request for the GetAccountInfo API.
    */
   public String getAccountInfoRequest(String authToken, String accountId) {
-    String getInfoRequest = getXmlFile("soap/requests/GetAccountInfoRequest.xml");
+    String getAccountInfoRequest = getXmlFile("soap/requests/GetAccountInfoRequest.xml");
 
-    return getInfoRequest
+    return getAccountInfoRequest
       .replaceAll("%AUTH_TOKEN%", authToken)
       .replaceAll("%ACCOUNT_ID%", accountId);
   }
@@ -44,13 +53,55 @@ public class SoapHttpUtils {
    */
   public String getAccountInfoResponse(String accountId, String accountEmail, String accountDomain,
     String accountFullName) {
-    String getInfoRequest = getXmlFile("soap/responses/GetAccountInfoResponse.xml");
+    String getAccountInfoResponse = getXmlFile("soap/responses/GetAccountInfoResponse.xml");
 
-    return getInfoRequest
+    return getAccountInfoResponse
       .replaceAll("%ACCOUNT_ID%", accountId)
       .replaceAll("%ACCOUNT_EMAIL%", accountEmail)
       .replaceAll("%ACCOUNT_DOMAIN%", accountDomain)
       .replaceAll("%ACCOUNT_FULL_NAME%", accountFullName);
+  }
+
+  /**
+   * Creates the GetInfoRequest XML body substituting the auth token in the related placeholders.
+   *
+   * @param authToken is a {@links String} representing the auth token of the requester
+   * @return a {@link String} representing the XML body request for the GetInfo API.
+   */
+  public String getInfoRequest(String authToken) {
+    String getInfoRequest = getXmlFile("soap/requests/GetInfoRequest.xml");
+
+    return getInfoRequest.replaceAll("%AUTH_TOKEN%", authToken);
+  }
+
+  /**
+   * Creates the GetInfoResponse XML body substituting the input parameters in the related
+   * placeholders.
+   *
+   * @param accountId       is a {@link String} representing the identifier of the retrieved
+   *                        account
+   * @param accountEmail    is a {@link String} representing the email of the retrieved account
+   * @param accountDomain   is a {@link String} representing the domain of the retrieved account
+   * @param accountFullName is a {@link String} representing the full name of the retrieved account
+   * @param accountLocale   is a {@link String} representing the locale chosen by the retrieved
+   *                        account
+   * @return a {@link String} representing the XML payload response for the GetInfo API.
+   */
+  public String getInfoResponse(
+    String accountId,
+    String accountEmail,
+    String accountDomain,
+    String accountFullName,
+    String accountLocale
+  ) {
+    String getInfoResponse = getXmlFile("soap/responses/GetInfoResponse.xml");
+
+    return getInfoResponse
+      .replaceAll("%ACCOUNT_ID%", accountId)
+      .replaceAll("%ACCOUNT_EMAIL%", accountEmail)
+      .replaceAll("%ACCOUNT_DOMAIN%", accountDomain)
+      .replaceAll("%ACCOUNT_FULL_NAME%", accountFullName)
+      .replaceAll("%ACCOUNT_LOCALE%", accountLocale);
   }
 
   /**

--- a/core/src/test/java-it/com/zextras/carbonio/user_management/apis/GetMyselfByCookieApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/user_management/apis/GetMyselfByCookieApiIT.java
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.user_management.apis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zextras.carbonio.user_management.Simulator;
+import com.zextras.carbonio.user_management.Simulator.SimulatorBuilder;
+import com.zextras.carbonio.user_management.SoapHttpUtils;
+import com.zextras.carbonio.user_management.generated.model.Locale;
+import com.zextras.carbonio.user_management.generated.model.UserMyself;
+import org.assertj.core.api.Assertions;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.HttpTester.Response;
+import org.eclipse.jetty.server.LocalConnector;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+
+public class GetMyselfByCookieApiIT {
+
+  static Simulator simulator;
+
+  @BeforeAll
+  static void init() {
+    simulator = SimulatorBuilder
+      .aSimulator()
+      .init()
+      .withMailboxService()
+      .build()
+      .start();
+  }
+
+  @BeforeEach
+  void setup() {
+    simulator.resetAll();
+  }
+
+  @AfterAll
+  static void cleanUpAll() {
+    simulator.close();
+  }
+
+  @Test
+  void givenAValidUserCookieTheGetUserMyselfApiShouldReturnTheRequesterFullInfo() throws Exception {
+    // Given
+    SoapHttpUtils soapHttpUtils = simulator.getSoapHttpUtils();
+    MockServerClient mailboxServiceMock = simulator.getMailboxServiceMock();
+
+    mailboxServiceMock
+      .when(HttpRequest
+        .request()
+        .withMethod(HttpMethod.POST.toString())
+        .withPath("/service/soap/")
+        .withBody(
+          soapHttpUtils.getInfoRequest("valid-token"))
+      )
+      .respond(HttpResponse
+        .response()
+        .withStatusCode(HttpStatus.OK_200)
+        .withBody(
+          soapHttpUtils.getInfoResponse(
+            "a28fdb4d-9f4b-4c7f-a572-43cef33f1d8b",
+            "fake@example.com",
+            "example.com",
+            "Fake Account",
+            "en"
+          )
+        ));
+
+    LocalConnector httpLocalConnector = simulator.getHttpLocalConnector();
+    HttpTester.Request request = HttpTester.newRequest();
+    request.setMethod(HttpMethod.GET.toString());
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=valid-token");
+    request.setURI(("/users/myself"));
+
+    // When
+    Response response =
+      HttpTester.parseResponse(HttpTester.from(httpLocalConnector.getResponse(request.generate())));
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+
+    UserMyself userMyself = new ObjectMapper().readValue(response.getContent(), UserMyself.class);
+    Assertions.assertThat(userMyself.getId().getUserId())
+      .isEqualTo("a28fdb4d-9f4b-4c7f-a572-43cef33f1d8b");
+    Assertions.assertThat(userMyself.getEmail()).isEqualTo("fake@example.com");
+    Assertions.assertThat(userMyself.getDomain()).isEqualTo("example.com");
+    Assertions.assertThat(userMyself.getFullName()).isEqualTo("Fake Account");
+    Assertions.assertThat(userMyself.getLocale()).isEqualTo(Locale.EN);
+  }
+
+  @Test
+  void givenAnInvalidUserCookieTheGetUserMyselfApiShouldReturnANotFoundResponse() throws Exception {
+    // Given
+    SoapHttpUtils soapHttpUtils = simulator.getSoapHttpUtils();
+    MockServerClient mailboxServiceMock = simulator.getMailboxServiceMock();
+
+    mailboxServiceMock
+      .when(HttpRequest
+        .request()
+        .withMethod(HttpMethod.POST.toString())
+        .withPath("/service/soap/")
+        .withBody(
+          soapHttpUtils.getInfoRequest("invalid-token"))
+      )
+      .respond(HttpResponse
+        .response()
+        .withStatusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
+        .withBody(soapHttpUtils.getSoapNotFoundErrorResponse())
+      );
+
+    LocalConnector httpLocalConnector = simulator.getHttpLocalConnector();
+    HttpTester.Request request = HttpTester.newRequest();
+    request.setMethod(HttpMethod.GET.toString());
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=invalid-token");
+    request.setURI(("/users/myself"));
+
+    // When
+    Response response = HttpTester
+      .parseResponse(HttpTester.from(httpLocalConnector.getResponse(request.generate())));
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND_404);
+    Assertions.assertThat(response.getContent()).hasSize(0);
+  }
+
+
+  @Test
+  void givenAValidUserCookieAndAnInvalidResponseFromTheMailboxTheGetUserMyselfApiShouldReturnANotFoundResponse()
+    throws Exception {
+    // Given
+    SoapHttpUtils soapHttpUtils = simulator.getSoapHttpUtils();
+    MockServerClient mailboxServiceMock = simulator.getMailboxServiceMock();
+
+    mailboxServiceMock
+      .when(HttpRequest
+        .request()
+        .withMethod(HttpMethod.POST.toString())
+        .withPath("/service/soap/")
+        .withBody(
+          soapHttpUtils.getInfoRequest("valid-token"))
+      )
+      .respond(HttpResponse
+        .response()
+        .withStatusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
+        .withBody("wrong response")
+      );
+
+    LocalConnector httpLocalConnector = simulator.getHttpLocalConnector();
+    HttpTester.Request request = HttpTester.newRequest();
+    request.setMethod(HttpMethod.GET.toString());
+    request.setHeader(HttpHeader.HOST.toString(), "test");
+    request.setHeader(HttpHeader.COOKIE.toString(), "ZM_AUTH_TOKEN=valid-token");
+    request.setURI(("/users/myself"));
+
+    // When
+    Response response = HttpTester
+      .parseResponse(HttpTester.from(httpLocalConnector.getResponse(request.generate())));
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR_500);
+    Assertions
+      .assertThat(response.getContent())
+      .hasSize(64)
+      .isEqualTo("Unable to get account user info due to an internal service error");
+  }
+}

--- a/core/src/test/java-it/com/zextras/carbonio/user_management/apis/GetUserByIdApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/user_management/apis/GetUserByIdApiIT.java
@@ -18,13 +18,12 @@ import org.eclipse.jetty.http.HttpTester.Response;
 import org.eclipse.jetty.server.LocalConnector;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
-class UsersApiIT {
+class GetUserByIdApiIT {
 
   private static Simulator simulator;
 
@@ -43,7 +42,6 @@ class UsersApiIT {
     simulator.close();
   }
 
-  @Disabled // Re-enabled it after the soap schema alignment
   @Test
   void givenAnExistingUserIdTheGetUserByIdApiShouldReturnTheRequestedUserInfo() throws Exception {
     // Given
@@ -78,13 +76,13 @@ class UsersApiIT {
     request.setURI(("/users/id/a28fdb4d-9f4b-4c7f-a572-43cef33f1d8b"));
 
     // When
-    Response httpFields =
+    Response response =
       HttpTester.parseResponse(HttpTester.from(localConnector.getResponse(request.generate())));
 
     // Then
-    Assertions.assertThat(httpFields.getStatus()).isEqualTo(HttpStatus.OK_200);
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
 
-    UserInfo userInfo = new ObjectMapper().readValue(httpFields.getContent(), UserInfo.class);
+    UserInfo userInfo = new ObjectMapper().readValue(response.getContent(), UserInfo.class);
 
     Assertions
       .assertThat(userInfo.getId().getUserId())

--- a/core/src/test/java-ut/com/zextras/carbonio/user_management/controllers/UsersApiControllerTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/user_management/controllers/UsersApiControllerTest.java
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package com.zextras.carbonio.user_management.controllers;
+
+import com.zextras.carbonio.user_management.exceptions.ServiceException;
+import com.zextras.carbonio.user_management.generated.model.UserMyself;
+import com.zextras.carbonio.user_management.services.UserService;
+import java.util.Optional;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class UsersApiControllerTest {
+
+  static UsersApiController usersApiController;
+  static UserService userServiceMock;
+
+  @BeforeAll
+  static void  init() {
+    userServiceMock = Mockito.mock(UserService.class);
+    usersApiController = new UsersApiController(userServiceMock);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    Mockito.reset(userServiceMock);
+  }
+
+  @Test
+  void givenAValidAuthTokenTheGetMyselfByCookieShouldReturnTheOkStatusCodeAndTheUserMyselfObject() {
+    // Given
+    String cookie = "ZM_AUTH_TOKEN=valid-token;";
+    String token = "valid-token";
+
+    UserMyself myselfMock = Mockito.mock(UserMyself.class);
+    Mockito.when(userServiceMock.getMyselfByToken(token)).thenReturn(Optional.of(myselfMock));
+
+    // When
+    Response response = usersApiController.getMyselfByCookie(cookie, Mockito.mock(SecurityContext.class));
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+    Assertions
+      .assertThat(response.getEntity())
+      .isInstanceOf(UserMyself.class)
+      .isEqualTo(myselfMock);
+  }
+
+  @Test
+  void givenAnInvalidAuthTokenTheGetMyselfByCookieShouldReturnTheNotFoundStatusCode() {
+    // Given
+    String cookie = "ZM_AUTH_TOKEN=invalid-token;";
+    String token = "invalid-token";
+
+    Mockito.when(userServiceMock.getMyselfByToken(token)).thenReturn(Optional.empty());
+
+    // When
+    Response response = usersApiController.getMyselfByCookie(cookie, Mockito.mock(SecurityContext.class));
+
+    // Then
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND_404);
+    Assertions.assertThat(response.getLength()).isEqualTo(-1);
+  }
+
+  @Test
+  void givenAValidTokenAndAServiceExceptionByTheUserServiceTheGetMyselfByCookieShouldThrowAServiceException() {
+    // Given
+    String cookie = "ZM_AUTH_TOKEN=valid-token;";
+    String token = "valid-token";
+
+    Mockito.when(userServiceMock.getMyselfByToken(token)).thenThrow(ServiceException.class);
+
+    // When
+    ThrowableAssert.ThrowingCallable callable =
+      () -> usersApiController.getMyselfByCookie(cookie, Mockito.mock(SecurityContext.class));
+
+    // Then
+    Assertions.assertThatExceptionOfType(ServiceException.class).isThrownBy(callable);
+  }
+
+}

--- a/core/src/test/resources/soap/requests/GetInfoRequest.xml
+++ b/core/src/test/resources/soap/requests/GetInfoRequest.xml
@@ -11,8 +11,6 @@
     </context>
   </S:Header>
   <S:Body>
-    <ns4:GetAccountInfoRequest xmlns="urn:zimbraAdminExt" xmlns:ns2="urn:zimbraAdmin" xmlns:ns3="urn:zimbraMail" xmlns:ns4="urn:zimbraAccount" xmlns:ns5="urn:zimbra">
-      <ns4:account by="id">%ACCOUNT_ID%</ns4:account>
-    </ns4:GetAccountInfoRequest>
+    <ns4:GetInfoRequest xmlns="urn:zimbraAdminExt" xmlns:ns2="urn:zimbraAdmin" xmlns:ns3="urn:zimbraMail" xmlns:ns4="urn:zimbraAccount" xmlns:ns5="urn:zimbra" sections="children,prefs"/>
   </S:Body>
 </S:Envelope>

--- a/core/src/test/resources/soap/requests/GetInfoRequest.xml
+++ b/core/src/test/resources/soap/requests/GetInfoRequest.xml
@@ -11,6 +11,6 @@
     </context>
   </S:Header>
   <S:Body>
-    <ns4:GetInfoRequest xmlns="urn:zimbraAdminExt" xmlns:ns2="urn:zimbraAdmin" xmlns:ns3="urn:zimbraMail" xmlns:ns4="urn:zimbraAccount" xmlns:ns5="urn:zimbra" sections="children,prefs"/>
+    <ns4:GetInfoRequest xmlns="urn:zimbraAdminExt" xmlns:ns2="urn:zimbraAdmin" xmlns:ns3="urn:zimbraMail" xmlns:ns4="urn:zimbraAccount" xmlns:ns5="urn:zimbra" sections="children,attrs,prefs"/>
   </S:Body>
 </S:Envelope>

--- a/core/src/test/resources/soap/responses/GetAccountInfoResponse.xml
+++ b/core/src/test/resources/soap/responses/GetAccountInfoResponse.xml
@@ -1,11 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-
-<!--
-  SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
-
-  SPDX-License-Identifier: AGPL-3.0-only
- -->
-
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
   <soap:Header>
     <context xmlns="urn:zimbra">

--- a/core/src/test/resources/soap/responses/GetInfoResponse.xml
+++ b/core/src/test/resources/soap/responses/GetInfoResponse.xml
@@ -1,0 +1,29 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Header>
+    <context xmlns="urn:zimbra">
+      <change token="48259"/>
+    </context>
+  </soap:Header>
+  <soap:Body>
+    <GetInfoResponse docSizeLimit="10485760" attSizeLimit="10240000" xmlns="urn:zimbraAccount">
+      <version>23.9.0_ZEXTRAS_202309 carbonio 20230816-0759 FOSS</version>
+      <id>%ACCOUNT_ID%</id>
+      <name>%ACCOUNT_EMAIL%</name>
+      <crumb>a32b032208b7e0d53eb7a6559e74f2d3</crumb>
+      <lifetime>172778688</lifetime>
+      <cos name="default" id="e00428a1-0c00-11d9-836a-000d93afea2a"/>
+      <prefs>
+        <!-- Here only the used prefs are listed -->
+        <pref name="zimbraPrefLocale">%ACCOUNT_LOCALE%</pref>
+      </prefs>
+      <attrs>
+        <!-- Here only the used attrs are listed -->
+        <attr name="displayName">%ACCOUNT_FULL_NAME%</attr>
+      </attrs>
+      <soapURL>https://%ACCOUNT_DOMAIN%/service/soap/</soapURL>
+      <publicURL>%ACCOUNT_DOMAIN%</publicURL>
+      <adminURL>https://%ACCOUNT_DOMAIN%:9071/carbonioAdmin</adminURL>
+      <pasteitcleanedEnabled>0</pasteitcleanedEnabled>
+    </GetInfoResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/core/src/test/resources/soap/responses/SoapNotFoundError.xml
+++ b/core/src/test/resources/soap/responses/SoapNotFoundError.xml
@@ -1,0 +1,17 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Header>
+    <context xmlns="urn:zimbra"/>
+  </soap:Header>
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>soap:Client</faultcode>
+      <faultstring>no valid authtoken present</faultstring>
+      <detail>
+        <Error xmlns="urn:zimbra">
+          <Code>service.AUTH_REQUIRED</Code>
+          <Trace>qtp560549459-94091:1693211656675:09cbc00a5bd780ff</Trace>
+        </Error>
+      </detail>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -73,6 +73,9 @@ postinst() {
   getent passwd 'carbonio-user-management' >/dev/null ||
     useradd -r -M -g 'carbonio-user-management' -s /sbin/nologin 'carbonio-user-management'
 
+  mkdir -p "/var/log/carbonio/user-management/"
+  chown carbonio-user-management:carbonio-user-management "/var/log/carbonio/user-management"
+
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl enable carbonio-user-management.service >/dev/null 2>&1 || :

--- a/package/intentions.json
+++ b/package/intentions.json
@@ -199,6 +199,21 @@
         {
           "Action": "allow",
           "HTTP": {
+            "PathPrefix": "/users/myself/",
+            "Header": [
+              {
+                "Name": "Cookie",
+                "Present": true
+              }
+            ],
+            "Methods": [
+              "GET"
+            ]
+          }
+        },
+        {
+          "Action": "allow",
+          "HTTP": {
             "PathPrefix": "/health/",
             "Methods": [
               "GET"

--- a/package/intentions.json.license
+++ b/package/intentions.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only

--- a/package/policies.json.license
+++ b/package/policies.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only

--- a/package/service-protocol.json.license
+++ b/package/service-protocol.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only

--- a/pacur.json.license
+++ b/pacur.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only

--- a/resources/user-management.yaml
+++ b/resources/user-management.yaml
@@ -90,12 +90,12 @@ paths:
       summary: |
         Gets the detailed account info of the user making the request. The details are
         fetched by the requester cookie.
-      operationId: getUserInfoByCookie
+      operationId: getMyselfByCookie
       parameters:
         - $ref: '#/components/parameters/headerCookie'
       responses:
         '200':
-          $ref: '#/components/responses/200UserInfo'
+          $ref: '#/components/responses/200UsersMyself'
         '404':
           $ref: '#/components/responses/404NotFound'
   /auth/token/{tokenId}:
@@ -190,6 +190,12 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/UserInfo'
+    200UsersMyself:
+      description: Account complete of all the information of the requester
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UserMyself'
     204NoContent:
       description: The service is up and running
     400BadRequest:
@@ -215,6 +221,18 @@ components:
           type: string
         domain:
           type: string
+    UserMyself:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UserId'
+        email:
+          type: string
+          format: email
+        fullName:
+          type: string
+        domain:
+          type: string
         locale:
           $ref: '#/components/schemas/Locale'
     UserId:
@@ -225,20 +243,20 @@ components:
     Locale:
       type: string
       enum:
-        - zh_CN
-        - nl
-        - en
-        - de
-        - hi
-        - it
-        - ja
-        - pt
-        - pl
-        - pt_BR
-        - ro
-        - ru
-        - es
-        - th
-        - tr
-        - fr
-        - vi
+        - DE
+        - EN
+        - ES
+        - FR
+        - HI
+        - IT
+        - JA
+        - NL
+        - PL
+        - PT
+        - PT_BR
+        - RO
+        - RU
+        - TH
+        - TR
+        - VI
+        - ZH_CN

--- a/resources/user-management.yaml
+++ b/resources/user-management.yaml
@@ -89,7 +89,7 @@ paths:
         - User
       summary: |
         Gets the detailed account info of the user making the request. The details are
-        fetched by the requester cookie.
+        fetched with the requester cookie.
       operationId: getMyselfByCookie
       parameters:
         - $ref: '#/components/parameters/headerCookie'

--- a/resources/user-management.yaml
+++ b/resources/user-management.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.3
 info:
   title: UserManagement API
   description: UserManagement API
-  version: 0.1.0
+  version: 0.2.5
 servers:
   - url: 'https://example.com/services/user-management/'
 tags:
@@ -81,6 +81,21 @@ paths:
           $ref: '#/components/responses/400BadRequest'
         '403':
           $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+  /users/myself:
+    get:
+      tags:
+        - User
+      summary: |
+        Gets the detailed account info of the user making the request. The details are
+        fetched by the requester cookie.
+      operationId: getUserInfoByCookie
+      parameters:
+        - $ref: '#/components/parameters/headerCookie'
+      responses:
+        '200':
+          $ref: '#/components/responses/200UserInfo'
         '404':
           $ref: '#/components/responses/404NotFound'
   /auth/token/{tokenId}:
@@ -200,8 +215,30 @@ components:
           type: string
         domain:
           type: string
+        locale:
+          $ref: '#/components/schemas/Locale'
     UserId:
       type: object
       properties:
         userId:
           type: string
+    Locale:
+      type: string
+      enum:
+        - zh_CN
+        - nl
+        - en
+        - de
+        - hi
+        - it
+        - ja
+        - pt
+        - pl
+        - pt_BR
+        - ro
+        - ru
+        - es
+        - th
+        - tr
+        - fr
+        - vi

--- a/soapclient/src/main/java/client/SoapClient.java
+++ b/soapclient/src/main/java/client/SoapClient.java
@@ -140,7 +140,7 @@ public class SoapClient {
     throws JAXBException, ParserConfigurationException, ServerSOAPFaultException {
 
     GetInfoRequest infoRequest = new GetInfoRequest();
-    infoRequest.setSections("children,prefs");
+    infoRequest.setSections("children,attrs,prefs");
 
     ZcsPortType zimbraService = getZimbraService();
 

--- a/soapclient/src/main/java/client/SoapClient.java
+++ b/soapclient/src/main/java/client/SoapClient.java
@@ -137,7 +137,7 @@ public class SoapClient {
   }
 
   public GetInfoResponse getAccountInfoByAuthToken()
-    throws JAXBException, ParserConfigurationException {
+    throws JAXBException, ParserConfigurationException, ServerSOAPFaultException {
 
     GetInfoRequest infoRequest = new GetInfoRequest();
     infoRequest.setSections("children,prefs");

--- a/soapclient/src/main/java/client/SoapClient.java
+++ b/soapclient/src/main/java/client/SoapClient.java
@@ -136,6 +136,22 @@ public class SoapClient {
     }
   }
 
+  public GetInfoResponse getAccountInfoByAuthToken()
+    throws JAXBException, ParserConfigurationException {
+
+    GetInfoRequest infoRequest = new GetInfoRequest();
+    infoRequest.setSections("children,prefs");
+
+    ZcsPortType zimbraService = getZimbraService();
+
+    try {
+      ((WSBindingProvider) zimbraService).setOutboundHeaders(createServiceSoapHeader());
+      return zimbraService.getInfoRequest(infoRequest, soapHeaderContext);
+    } finally {
+      zimbraServiceQueue.add(zimbraService);
+    }
+  }
+
   public GetInfoResponse validateAuthToken()
     throws JAXBException, ParserConfigurationException, ServerSOAPFaultException {
 


### PR DESCRIPTION
- [feat: implement /users/myself API to expose the user locale prefs](https://github.com/zextras/carbonio-user-management/commit/af0c313f37f1bdb17bf0620ca644474120dffa6f) and [feat: final implementation of /users/myself API](https://github.com/zextras/carbonio-user-management/commit/e87dcd00e00417b53a3e3b13c39ebac2ff67964d):
  - Updated the openapi schema adding:
    - a new entrypoint "/users/myself" necessary to get the UseMyself
      containing the Locale attribute;
    - a new enumerator (Locale) representing all the locales supported by
      Carbonio.
  - Implemented the related methods in the UserApiController and in the
    UserService to retrieve the full details of the User (requester) via
    the SoapClient.
  - Added the SoapClient#getAccountInfoByAuthToken method to retrieve the
    full details of the requester using its cookie.
  - Added the ServiceException and the ServiceExceptionMapper to better
    handling the internal service errors: they avoid to have checked
    exceptions but it allows to handle the scenario where the service
    throws errors (expecially in the SoapClient).

- [test: add ITs for the GetMyselfByCookie API and add UTs for the controller](https://github.com/zextras/carbonio-user-management/commit/b00640b4ca0ac733f19543621b532d61aad1ddad)

- [chore(log): add logback.xml in prod and create the /var/log/user-management folder](https://github.com/zextras/carbonio-user-management/commit/deb52987ab4ae734e0606be40bf02910b0c984f2)

- [chore(license): add dep5 and remove .license files](https://github.com/zextras/carbonio-user-management/commit/dddd2ca57369cc13b00484f2543f19967a04152f)