### PR TITLE
chore(sync): UM-24 - Update WSDL schema to regenerate the SoapClient

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,14 +25,14 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.3.0-1</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>com.zextras.carbonio.user-management</groupId>
       <artifactId>carbonio-user-management-core</artifactId>
-      <version>0.3.0-1</version>
+      <version>0.3.1-SNAPSHOT</version>
     </dependency>
 
     <!-- Guice dependencies -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.3.0-1</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>
@@ -42,7 +42,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.soap-client</groupId>
       <artifactId>carbonio-soap-client</artifactId>
-      <version>0.3.0-1</version>
+      <version>0.3.1-1</version>
     </dependency>
 
     <!-- Guice dependencies -->

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.3.0-1</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -7,8 +7,8 @@ targets=(
   "centos"
 )
 pkgname="carbonio-user-management"
-pkgver="0.3.0"
-pkgrel="1"
+pkgver="0.3.1"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio User Management"
 pkgdesclong=(
   "Carbonio User Management"

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.3.0-1</version>
+  <version>0.3.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-user-management</name>

--- a/resources/user-management.yaml
+++ b/resources/user-management.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.3
 info:
   title: UserManagement API
   description: UserManagement API
-  version: 0.3.0
+  version: 0.3.1
 servers:
   - url: 'https://example.com/services/user-management/'
 tags:

--- a/soapclient/pom.xml
+++ b/soapclient/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.soap-client</groupId>
   <artifactId>carbonio-soap-client</artifactId>
-  <version>0.3.0-1</version>
+  <version>0.3.1-1</version>
 
   <name>carbonio-soap-client</name>
 

--- a/soapclient/schemas/ZimbraService.wsdl
+++ b/soapclient/schemas/ZimbraService.wsdl
@@ -232,12 +232,6 @@
   <wsdl:message name="AccountModifyPrefsResponseMessage">
     <wsdl:part name="params" element="zimbraAccount:ModifyPrefsResponse"/>
   </wsdl:message>
-  <wsdl:message name="AccountModifyPropertiesRequestMessage">
-    <wsdl:part name="params" element="zimbraAccount:ModifyPropertiesRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AccountModifyPropertiesResponseMessage">
-    <wsdl:part name="params" element="zimbraAccount:ModifyPropertiesResponse"/>
-  </wsdl:message>
   <wsdl:message name="AccountModifySignatureRequestMessage">
     <wsdl:part name="params" element="zimbraAccount:ModifySignatureRequest"/>
   </wsdl:message>
@@ -249,12 +243,6 @@
   </wsdl:message>
   <wsdl:message name="AccountModifyWhiteBlackListResponseMessage">
     <wsdl:part name="params" element="zimbraAccount:ModifyWhiteBlackListResponse"/>
-  </wsdl:message>
-  <wsdl:message name="AccountModifyZimletPrefsRequestMessage">
-    <wsdl:part name="params" element="zimbraAccount:ModifyZimletPrefsRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AccountModifyZimletPrefsResponseMessage">
-    <wsdl:part name="params" element="zimbraAccount:ModifyZimletPrefsResponse"/>
   </wsdl:message>
   <wsdl:message name="AccountResetPasswordRequestMessage">
     <wsdl:part name="params" element="zimbraAccount:ResetPasswordRequest"/>
@@ -1150,12 +1138,6 @@
   <wsdl:message name="AdminComputeAggregateQuotaUsageResponseMessage">
     <wsdl:part name="params" element="zimbraAdmin:ComputeAggregateQuotaUsageResponse"/>
   </wsdl:message>
-  <wsdl:message name="AdminConfigureZimletRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:ConfigureZimletRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminConfigureZimletResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:ConfigureZimletResponse"/>
-  </wsdl:message>
   <wsdl:message name="AdminContactBackupRequestMessage">
     <wsdl:part name="params" element="zimbraAdmin:ContactBackupRequest"/>
   </wsdl:message>
@@ -1270,12 +1252,6 @@
   <wsdl:message name="AdminCreateXMbxSearchResponseMessage">
     <wsdl:part name="params" element="zimbraAdmin:CreateXMbxSearchResponse"/>
   </wsdl:message>
-  <wsdl:message name="AdminCreateZimletRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:CreateZimletRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminCreateZimletResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:CreateZimletResponse"/>
-  </wsdl:message>
   <wsdl:message name="AdminDedupeBlobsRequestMessage">
     <wsdl:part name="params" element="zimbraAdmin:DedupeBlobsRequest"/>
   </wsdl:message>
@@ -1371,18 +1347,6 @@
   </wsdl:message>
   <wsdl:message name="AdminDeleteXMbxSearchResponseMessage">
     <wsdl:part name="params" element="zimbraAdmin:DeleteXMbxSearchResponse"/>
-  </wsdl:message>
-  <wsdl:message name="AdminDeleteZimletRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:DeleteZimletRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminDeleteZimletResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:DeleteZimletResponse"/>
-  </wsdl:message>
-  <wsdl:message name="AdminDeployZimletRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:DeployZimletRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminDeployZimletResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:DeployZimletResponse"/>
   </wsdl:message>
   <wsdl:message name="AdminDisableArchiveRequestMessage">
     <wsdl:part name="params" element="zimbraAdmin:DisableArchiveRequest"/>
@@ -1485,12 +1449,6 @@
   </wsdl:message>
   <wsdl:message name="AdminGetAdminConsoleUICompResponseMessage">
     <wsdl:part name="params" element="zimbraAdmin:GetAdminConsoleUICompResponse"/>
-  </wsdl:message>
-  <wsdl:message name="AdminGetAdminExtensionZimletsRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:GetAdminExtensionZimletsRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminGetAdminExtensionZimletsResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:GetAdminExtensionZimletsResponse"/>
   </wsdl:message>
   <wsdl:message name="AdminGetAdminSavedSearchesRequestMessage">
     <wsdl:part name="params" element="zimbraAdmin:GetAdminSavedSearchesRequest"/>
@@ -1605,12 +1563,6 @@
   </wsdl:message>
   <wsdl:message name="AdminGetAllXMPPComponentsResponseMessage">
     <wsdl:part name="params" element="zimbraAdmin:GetAllXMPPComponentsResponse"/>
-  </wsdl:message>
-  <wsdl:message name="AdminGetAllZimletsRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:GetAllZimletsRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminGetAllZimletsResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:GetAllZimletsResponse"/>
   </wsdl:message>
   <wsdl:message name="AdminGetApplianceHSMFSRequestMessage">
     <wsdl:part name="params" element="zimbraAdmin:GetApplianceHSMFSRequest"/>
@@ -1894,18 +1846,6 @@
   <wsdl:message name="AdminGetXMbxSearchesListResponseMessage">
     <wsdl:part name="params" element="zimbraAdmin:GetXMbxSearchesListResponse"/>
   </wsdl:message>
-  <wsdl:message name="AdminGetZimletRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:GetZimletRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminGetZimletResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:GetZimletResponse"/>
-  </wsdl:message>
-  <wsdl:message name="AdminGetZimletStatusRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:GetZimletStatusRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminGetZimletStatusResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:GetZimletStatusResponse"/>
-  </wsdl:message>
   <wsdl:message name="AdminGrantRightRequestMessage">
     <wsdl:part name="params" element="zimbraAdmin:GrantRightRequest"/>
   </wsdl:message>
@@ -2061,12 +2001,6 @@
   </wsdl:message>
   <wsdl:message name="AdminModifyVolumeResponseMessage">
     <wsdl:part name="params" element="zimbraAdmin:ModifyVolumeResponse"/>
-  </wsdl:message>
-  <wsdl:message name="AdminModifyZimletRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:ModifyZimletRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminModifyZimletResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:ModifyZimletResponse"/>
   </wsdl:message>
   <wsdl:message name="AdminMoveBlobsRequestMessage">
     <wsdl:part name="params" element="zimbraAdmin:MoveBlobsRequest"/>
@@ -2320,12 +2254,6 @@
   <wsdl:message name="AdminSyncGalAccountResponseMessage">
     <wsdl:part name="params" element="zimbraAdmin:SyncGalAccountResponse"/>
   </wsdl:message>
-  <wsdl:message name="AdminUndeployZimletRequestMessage">
-    <wsdl:part name="params" element="zimbraAdmin:UndeployZimletRequest"/>
-  </wsdl:message>
-  <wsdl:message name="AdminUndeployZimletResponseMessage">
-    <wsdl:part name="params" element="zimbraAdmin:UndeployZimletResponse"/>
-  </wsdl:message>
   <wsdl:message name="AdminUnloadMailboxRequestMessage">
     <wsdl:part name="params" element="zimbraAdmin:UnloadMailboxRequest"/>
   </wsdl:message>
@@ -2510,10 +2438,6 @@
       <wsdl:input message="svc:AdminComputeAggregateQuotaUsageRequestMessage"/>
       <wsdl:output message="svc:AdminComputeAggregateQuotaUsageResponseMessage"/>
     </wsdl:operation>
-    <wsdl:operation name="configureZimletRequest">
-      <wsdl:input message="svc:AdminConfigureZimletRequestMessage"/>
-      <wsdl:output message="svc:AdminConfigureZimletResponseMessage"/>
-    </wsdl:operation>
     <wsdl:operation name="contactBackupRequest">
       <wsdl:input message="svc:AdminContactBackupRequestMessage"/>
       <wsdl:output message="svc:AdminContactBackupResponseMessage"/>
@@ -2590,10 +2514,6 @@
       <wsdl:input message="svc:AdminCreateXMbxSearchRequestMessage"/>
       <wsdl:output message="svc:AdminCreateXMbxSearchResponseMessage"/>
     </wsdl:operation>
-    <wsdl:operation name="createZimletRequest">
-      <wsdl:input message="svc:AdminCreateZimletRequestMessage"/>
-      <wsdl:output message="svc:AdminCreateZimletResponseMessage"/>
-    </wsdl:operation>
     <wsdl:operation name="dedupeBlobsRequest">
       <wsdl:input message="svc:AdminDedupeBlobsRequestMessage"/>
       <wsdl:output message="svc:AdminDedupeBlobsResponseMessage"/>
@@ -2657,14 +2577,6 @@
     <wsdl:operation name="deleteXMbxSearchRequest">
       <wsdl:input message="svc:AdminDeleteXMbxSearchRequestMessage"/>
       <wsdl:output message="svc:AdminDeleteXMbxSearchResponseMessage"/>
-    </wsdl:operation>
-    <wsdl:operation name="deleteZimletRequest">
-      <wsdl:input message="svc:AdminDeleteZimletRequestMessage"/>
-      <wsdl:output message="svc:AdminDeleteZimletResponseMessage"/>
-    </wsdl:operation>
-    <wsdl:operation name="deployZimletRequest">
-      <wsdl:input message="svc:AdminDeployZimletRequestMessage"/>
-      <wsdl:output message="svc:AdminDeployZimletResponseMessage"/>
     </wsdl:operation>
     <wsdl:operation name="disableArchiveRequest">
       <wsdl:input message="svc:AdminDisableArchiveRequestMessage"/>
@@ -2733,10 +2645,6 @@
     <wsdl:operation name="getAdminConsoleUICompRequest">
       <wsdl:input message="svc:AdminGetAdminConsoleUICompRequestMessage"/>
       <wsdl:output message="svc:AdminGetAdminConsoleUICompResponseMessage"/>
-    </wsdl:operation>
-    <wsdl:operation name="getAdminExtensionZimletsRequest">
-      <wsdl:input message="svc:AdminGetAdminExtensionZimletsRequestMessage"/>
-      <wsdl:output message="svc:AdminGetAdminExtensionZimletsResponseMessage"/>
     </wsdl:operation>
     <wsdl:operation name="getAdminSavedSearchesRequest">
       <wsdl:input message="svc:AdminGetAdminSavedSearchesRequestMessage"/>
@@ -2813,10 +2721,6 @@
     <wsdl:operation name="getAllXMPPComponentsRequest">
       <wsdl:input message="svc:AdminGetAllXMPPComponentsRequestMessage"/>
       <wsdl:output message="svc:AdminGetAllXMPPComponentsResponseMessage"/>
-    </wsdl:operation>
-    <wsdl:operation name="getAllZimletsRequest">
-      <wsdl:input message="svc:AdminGetAllZimletsRequestMessage"/>
-      <wsdl:output message="svc:AdminGetAllZimletsResponseMessage"/>
     </wsdl:operation>
     <wsdl:operation name="getApplianceHSMFSRequest">
       <wsdl:input message="svc:AdminGetApplianceHSMFSRequestMessage"/>
@@ -3006,14 +2910,6 @@
       <wsdl:input message="svc:AdminGetXMbxSearchesListRequestMessage"/>
       <wsdl:output message="svc:AdminGetXMbxSearchesListResponseMessage"/>
     </wsdl:operation>
-    <wsdl:operation name="getZimletRequest">
-      <wsdl:input message="svc:AdminGetZimletRequestMessage"/>
-      <wsdl:output message="svc:AdminGetZimletResponseMessage"/>
-    </wsdl:operation>
-    <wsdl:operation name="getZimletStatusRequest">
-      <wsdl:input message="svc:AdminGetZimletStatusRequestMessage"/>
-      <wsdl:output message="svc:AdminGetZimletStatusResponseMessage"/>
-    </wsdl:operation>
     <wsdl:operation name="grantRightRequest">
       <wsdl:input message="svc:AdminGrantRightRequestMessage"/>
       <wsdl:output message="svc:AdminGrantRightResponseMessage"/>
@@ -3117,10 +3013,6 @@
     <wsdl:operation name="modifyVolumeRequest">
       <wsdl:input message="svc:AdminModifyVolumeRequestMessage"/>
       <wsdl:output message="svc:AdminModifyVolumeResponseMessage"/>
-    </wsdl:operation>
-    <wsdl:operation name="modifyZimletRequest">
-      <wsdl:input message="svc:AdminModifyZimletRequestMessage"/>
-      <wsdl:output message="svc:AdminModifyZimletResponseMessage"/>
     </wsdl:operation>
     <wsdl:operation name="moveBlobsRequest">
       <wsdl:input message="svc:AdminMoveBlobsRequestMessage"/>
@@ -3289,10 +3181,6 @@
     <wsdl:operation name="syncGalAccountRequest">
       <wsdl:input message="svc:AdminSyncGalAccountRequestMessage"/>
       <wsdl:output message="svc:AdminSyncGalAccountResponseMessage"/>
-    </wsdl:operation>
-    <wsdl:operation name="undeployZimletRequest">
-      <wsdl:input message="svc:AdminUndeployZimletRequestMessage"/>
-      <wsdl:output message="svc:AdminUndeployZimletResponseMessage"/>
     </wsdl:operation>
     <wsdl:operation name="unloadMailboxRequest">
       <wsdl:input message="svc:AdminUnloadMailboxRequestMessage"/>
@@ -3480,10 +3368,6 @@
       <wsdl:input message="svc:AccountModifyPrefsRequestMessage"/>
       <wsdl:output message="svc:AccountModifyPrefsResponseMessage"/>
     </wsdl:operation>
-    <wsdl:operation name="modifyPropertiesRequest">
-      <wsdl:input message="svc:AccountModifyPropertiesRequestMessage"/>
-      <wsdl:output message="svc:AccountModifyPropertiesResponseMessage"/>
-    </wsdl:operation>
     <wsdl:operation name="modifySignatureRequest">
       <wsdl:input message="svc:AccountModifySignatureRequestMessage"/>
       <wsdl:output message="svc:AccountModifySignatureResponseMessage"/>
@@ -3491,10 +3375,6 @@
     <wsdl:operation name="modifyWhiteBlackListRequest">
       <wsdl:input message="svc:AccountModifyWhiteBlackListRequestMessage"/>
       <wsdl:output message="svc:AccountModifyWhiteBlackListResponseMessage"/>
-    </wsdl:operation>
-    <wsdl:operation name="modifyZimletPrefsRequest">
-      <wsdl:input message="svc:AccountModifyZimletPrefsRequestMessage"/>
-      <wsdl:output message="svc:AccountModifyZimletPrefsResponseMessage"/>
     </wsdl:operation>
     <wsdl:operation name="resetPasswordRequest">
       <wsdl:input message="svc:AccountResetPasswordRequestMessage"/>
@@ -4275,16 +4155,6 @@
         <soap:body use="literal"/>
       </wsdl:output>
     </wsdl:operation>
-    <wsdl:operation name="configureZimletRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/ConfigureZimlet" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
     <wsdl:operation name="contactBackupRequest">
       <soap:operation soapAction="urn:zimbraAdmin/ContactBackup" style="document"/>
       <wsdl:input>
@@ -4475,16 +4345,6 @@
         <soap:body use="literal"/>
       </wsdl:output>
     </wsdl:operation>
-    <wsdl:operation name="createZimletRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/CreateZimlet" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
     <wsdl:operation name="dedupeBlobsRequest">
       <soap:operation soapAction="urn:zimbraAdmin/DedupeBlobs" style="document"/>
       <wsdl:input>
@@ -4637,26 +4497,6 @@
     </wsdl:operation>
     <wsdl:operation name="deleteXMbxSearchRequest">
       <soap:operation soapAction="urn:zimbraAdmin/DeleteXMbxSearch" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="deleteZimletRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/DeleteZimlet" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="deployZimletRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/DeployZimlet" style="document"/>
       <wsdl:input>
         <soap:body use="literal"/>
         <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
@@ -4827,16 +4667,6 @@
     </wsdl:operation>
     <wsdl:operation name="getAdminConsoleUICompRequest">
       <soap:operation soapAction="urn:zimbraAdmin/GetAdminConsoleUIComp" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getAdminExtensionZimletsRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/GetAdminExtensionZimlets" style="document"/>
       <wsdl:input>
         <soap:body use="literal"/>
         <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
@@ -5027,16 +4857,6 @@
     </wsdl:operation>
     <wsdl:operation name="getAllXMPPComponentsRequest">
       <soap:operation soapAction="urn:zimbraAdmin/GetAllXMPPComponents" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getAllZimletsRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/GetAllZimlets" style="document"/>
       <wsdl:input>
         <soap:body use="literal"/>
         <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
@@ -5515,26 +5335,6 @@
         <soap:body use="literal"/>
       </wsdl:output>
     </wsdl:operation>
-    <wsdl:operation name="getZimletRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/GetZimlet" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getZimletStatusRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/GetZimletStatus" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
     <wsdl:operation name="grantRightRequest">
       <soap:operation soapAction="urn:zimbraAdmin/GrantRight" style="document"/>
       <wsdl:input>
@@ -5787,16 +5587,6 @@
     </wsdl:operation>
     <wsdl:operation name="modifyVolumeRequest">
       <soap:operation soapAction="urn:zimbraAdmin/ModifyVolume" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="modifyZimletRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/ModifyZimlet" style="document"/>
       <wsdl:input>
         <soap:body use="literal"/>
         <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
@@ -6217,16 +6007,6 @@
     </wsdl:operation>
     <wsdl:operation name="syncGalAccountRequest">
       <soap:operation soapAction="urn:zimbraAdmin/SyncGalAccount" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="undeployZimletRequest">
-      <soap:operation soapAction="urn:zimbraAdmin/UndeployZimlet" style="document"/>
       <wsdl:input>
         <soap:body use="literal"/>
         <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
@@ -6698,16 +6478,6 @@
         <soap:body use="literal"/>
       </wsdl:output>
     </wsdl:operation>
-    <wsdl:operation name="modifyPropertiesRequest">
-      <soap:operation soapAction="urn:zimbraAccount/ModifyProperties" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
     <wsdl:operation name="modifySignatureRequest">
       <soap:operation soapAction="urn:zimbraAccount/ModifySignature" style="document"/>
       <wsdl:input>
@@ -6720,16 +6490,6 @@
     </wsdl:operation>
     <wsdl:operation name="modifyWhiteBlackListRequest">
       <soap:operation soapAction="urn:zimbraAccount/ModifyWhiteBlackList" style="document"/>
-      <wsdl:input>
-        <soap:body use="literal"/>
-        <soap:header message="svc:soapHdrContext" part="context" use="literal"/>
-      </wsdl:input>
-      <wsdl:output>
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="modifyZimletPrefsRequest">
-      <soap:operation soapAction="urn:zimbraAccount/ModifyZimletPrefs" style="document"/>
       <wsdl:input>
         <soap:body use="literal"/>
         <soap:header message="svc:soapHdrContext" part="context" use="literal"/>

--- a/soapclient/schemas/zimbraAccount.xsd
+++ b/soapclient/schemas/zimbraAccount.xsd
@@ -154,10 +154,6 @@
     
   <xs:element name="ModifyPrefsResponse" type="tns:modifyPrefsResponse"/>
     
-  <xs:element name="ModifyPropertiesRequest" type="tns:modifyPropertiesRequest"/>
-    
-  <xs:element name="ModifyPropertiesResponse" type="tns:modifyPropertiesResponse"/>
-    
   <xs:element name="ModifySignatureRequest" type="tns:modifySignatureRequest"/>
     
   <xs:element name="ModifySignatureResponse" type="tns:modifySignatureResponse"/>
@@ -165,10 +161,6 @@
   <xs:element name="ModifyWhiteBlackListRequest" type="tns:modifyWhiteBlackListRequest"/>
     
   <xs:element name="ModifyWhiteBlackListResponse" type="tns:modifyWhiteBlackListResponse"/>
-    
-  <xs:element name="ModifyZimletPrefsRequest" type="tns:modifyZimletPrefsRequest"/>
-    
-  <xs:element name="ModifyZimletPrefsResponse" type="tns:modifyZimletPrefsResponse"/>
     
   <xs:element name="ResetPasswordRequest" type="tns:resetPasswordRequest"/>
     
@@ -202,17 +194,9 @@
     
   <xs:element name="dl" type="tns:distributionListInfo"/>
     
-  <xs:element name="include" type="tns:accountZimletInclude"/>
-    
-  <xs:element name="includeCSS" type="tns:accountZimletIncludeCSS"/>
-    
   <xs:element name="meta" type="tns:accountCustomMetadata"/>
     
-  <xs:element name="serverExtension" type="tns:zimletServerExtension"/>
-    
   <xs:element name="signature" type="tns:signature"/>
-    
-  <xs:element name="target" type="tns:accountZimletTarget"/>
     
   <xs:complexType name="authRequest">
         
@@ -1414,36 +1398,6 @@
               
       </xs:element>
             
-      <xs:element minOccurs="0" name="zimlets">
-                
-        <xs:complexType>
-                    
-          <xs:sequence>
-                        
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="zimlet" type="tns:accountZimletInfo"/>
-                      
-          </xs:sequence>
-                  
-          <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-        </xs:complexType>
-              
-      </xs:element>
-            
-      <xs:element minOccurs="0" name="props">
-                
-        <xs:complexType>
-                    
-          <xs:sequence>
-                        
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="prop" type="tns:prop"/>
-                      
-          </xs:sequence>
-                  
-          <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-        </xs:complexType>
-              
-      </xs:element>
-            
       <xs:element minOccurs="0" name="identities">
                 
         <xs:complexType>
@@ -1561,175 +1515,6 @@
     <xs:attribute name="id" type="xs:string"/>
         
     <xs:attribute name="name" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="accountZimletInfo">
-        
-    <xs:sequence>
-            
-      <xs:element minOccurs="0" name="zimletContext" type="tns:accountZimletContext"/>
-            
-      <xs:element minOccurs="0" name="zimlet" type="tns:accountZimletDesc"/>
-            
-      <xs:element minOccurs="0" name="zimletConfig" type="tns:accountZimletConfigInfo"/>
-            
-      <xs:any namespace="##other" processContents="skip"/>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="accountZimletContext">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="baseUrl" type="xs:string" use="required"/>
-        
-    <xs:attribute name="priority" type="xs:int"/>
-        
-    <xs:attribute name="presence" type="xs:string" use="required"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="accountZimletDesc">
-        
-    <xs:sequence>
-            
-      <xs:choice maxOccurs="unbounded" minOccurs="0">
-                
-        <xs:element ref="tns:serverExtension"/>
-                
-        <xs:element ref="tns:include"/>
-                
-        <xs:element ref="tns:includeCSS"/>
-                
-        <xs:element ref="tns:target"/>
-                
-        <xs:any namespace="##other" processContents="skip"/>
-              
-      </xs:choice>
-          
-    </xs:sequence>
-        
-    <xs:attribute name="name" type="xs:string"/>
-        
-    <xs:attribute name="version" type="xs:string"/>
-        
-    <xs:attribute name="description" type="xs:string"/>
-        
-    <xs:attribute name="extension" type="xs:string"/>
-        
-    <xs:attribute name="target" type="xs:string"/>
-        
-    <xs:attribute name="label" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="zimletServerExtension">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="hasKeyword" type="xs:string"/>
-        
-    <xs:attribute name="extensionClass" type="xs:string"/>
-        
-    <xs:attribute name="regex" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:simpleType name="accountZimletInclude">
-        
-    <xs:restriction base="xs:string"/>
-      
-  </xs:simpleType>
-    
-  <xs:simpleType name="accountZimletIncludeCSS">
-        
-    <xs:restriction base="xs:string"/>
-      
-  </xs:simpleType>
-    
-  <xs:simpleType name="accountZimletTarget">
-        
-    <xs:restriction base="xs:string"/>
-      
-  </xs:simpleType>
-    
-  <xs:complexType name="accountZimletConfigInfo">
-        
-    <xs:all>
-            
-      <xs:element minOccurs="0" name="global" type="tns:accountZimletGlobalConfigInfo"/>
-            
-      <xs:element minOccurs="0" name="host" type="tns:accountZimletHostConfigInfo"/>
-          
-    </xs:all>
-        
-    <xs:attribute name="name" type="xs:string"/>
-        
-    <xs:attribute name="version" type="xs:string"/>
-        
-    <xs:attribute name="description" type="xs:string"/>
-        
-    <xs:attribute name="extension" type="xs:string"/>
-        
-    <xs:attribute name="target" type="xs:string"/>
-        
-    <xs:attribute name="label" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="accountZimletGlobalConfigInfo">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="tns:accountZimletProperty"/>
-          
-    </xs:sequence>
-      
-    <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-  </xs:complexType>
-    
-  <xs:complexType name="accountZimletProperty">
-        
-    <xs:simpleContent>
-            
-      <xs:extension base="xs:string">
-                
-        <xs:attribute name="name" type="xs:string"/>
-              
-      </xs:extension>
-          
-    </xs:simpleContent>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="accountZimletHostConfigInfo">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="tns:accountZimletProperty"/>
-          
-    </xs:sequence>
-        
-    <xs:attribute name="name" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="prop">
-        
-    <xs:simpleContent>
-            
-      <xs:extension base="xs:string">
-                
-        <xs:attribute name="zimlet" type="xs:string" use="required"/>
-                
-        <xs:attribute name="name" type="xs:string" use="required"/>
-              
-      </xs:extension>
-          
-    </xs:simpleContent>
       
   </xs:complexType>
     
@@ -2365,23 +2150,6 @@
       
   </xs:complexType>
     
-  <xs:complexType name="modifyPropertiesRequest">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" name="prop" type="tns:prop"/>
-          
-    </xs:sequence>
-      
-    <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-  </xs:complexType>
-    
-  <xs:complexType name="modifyPropertiesResponse">
-        
-    <xs:sequence/>
-      
-  </xs:complexType>
-    
   <xs:complexType name="modifySignatureRequest">
         
     <xs:sequence>
@@ -2440,38 +2208,6 @@
         
     <xs:sequence/>
       
-  </xs:complexType>
-    
-  <xs:complexType name="modifyZimletPrefsRequest">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="zimlet" type="tns:modifyZimletPrefsSpec"/>
-          
-    </xs:sequence>
-      
-    <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-  </xs:complexType>
-    
-  <xs:complexType name="modifyZimletPrefsSpec">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="name" type="xs:string" use="required"/>
-        
-    <xs:attribute name="presence" type="xs:string" use="required"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="modifyZimletPrefsResponse">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="zimlet" type="xs:string"/>
-          
-    </xs:sequence>
-      
-    <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
   </xs:complexType>
     
   <xs:complexType name="resetPasswordRequest">

--- a/soapclient/schemas/zimbraAdmin.xsd
+++ b/soapclient/schemas/zimbraAdmin.xsd
@@ -132,10 +132,6 @@
     
   <xs:element name="ComputeAggregateQuotaUsageResponse" type="tns:computeAggregateQuotaUsageResponse"/>
     
-  <xs:element name="ConfigureZimletRequest" type="tns:configureZimletRequest"/>
-    
-  <xs:element name="ConfigureZimletResponse" type="tns:configureZimletResponse"/>
-    
   <xs:element name="ContactBackupRequest" type="tns:contactBackupRequest"/>
     
   <xs:element name="ContactBackupResponse" type="tns:contactBackupResponse"/>
@@ -212,10 +208,6 @@
     
   <xs:element name="CreateXMbxSearchResponse" type="tns:createXMbxSearchResponse"/>
     
-  <xs:element name="CreateZimletRequest" type="tns:createZimletRequest"/>
-    
-  <xs:element name="CreateZimletResponse" type="tns:createZimletResponse"/>
-    
   <xs:element name="DedupeBlobsRequest" type="tns:dedupeBlobsRequest"/>
     
   <xs:element name="DedupeBlobsResponse" type="tns:dedupeBlobsResponse"/>
@@ -279,14 +271,6 @@
   <xs:element name="DeleteXMbxSearchRequest" type="tns:deleteXMbxSearchRequest"/>
     
   <xs:element name="DeleteXMbxSearchResponse" type="tns:deleteXMbxSearchResponse"/>
-    
-  <xs:element name="DeleteZimletRequest" type="tns:deleteZimletRequest"/>
-    
-  <xs:element name="DeleteZimletResponse" type="tns:deleteZimletResponse"/>
-    
-  <xs:element name="DeployZimletRequest" type="tns:deployZimletRequest"/>
-    
-  <xs:element name="DeployZimletResponse" type="tns:deployZimletResponse"/>
     
   <xs:element name="DisableArchiveRequest" type="tns:disableArchiveRequest"/>
     
@@ -355,10 +339,6 @@
   <xs:element name="GetAdminConsoleUICompRequest" type="tns:getAdminConsoleUICompRequest"/>
     
   <xs:element name="GetAdminConsoleUICompResponse" type="tns:getAdminConsoleUICompResponse"/>
-    
-  <xs:element name="GetAdminExtensionZimletsRequest" type="tns:getAdminExtensionZimletsRequest"/>
-    
-  <xs:element name="GetAdminExtensionZimletsResponse" type="tns:getAdminExtensionZimletsResponse"/>
     
   <xs:element name="GetAdminSavedSearchesRequest" type="tns:getAdminSavedSearchesRequest"/>
     
@@ -435,10 +415,6 @@
   <xs:element name="GetAllXMPPComponentsRequest" type="tns:getAllXMPPComponentsRequest"/>
     
   <xs:element name="GetAllXMPPComponentsResponse" type="tns:getAllXMPPComponentsResponse"/>
-    
-  <xs:element name="GetAllZimletsRequest" type="tns:getAllZimletsRequest"/>
-    
-  <xs:element name="GetAllZimletsResponse" type="tns:getAllZimletsResponse"/>
     
   <xs:element name="GetApplianceHSMFSRequest" type="tns:getApplianceHSMFSRequest"/>
     
@@ -628,14 +604,6 @@
     
   <xs:element name="GetXMbxSearchesListResponse" type="tns:getXMbxSearchesListResponse"/>
     
-  <xs:element name="GetZimletRequest" type="tns:getZimletRequest"/>
-    
-  <xs:element name="GetZimletResponse" type="tns:getZimletResponse"/>
-    
-  <xs:element name="GetZimletStatusRequest" type="tns:getZimletStatusRequest"/>
-    
-  <xs:element name="GetZimletStatusResponse" type="tns:getZimletStatusResponse"/>
-    
   <xs:element name="GrantRightRequest" type="tns:grantRightRequest"/>
     
   <xs:element name="GrantRightResponse" type="tns:grantRightResponse"/>
@@ -739,10 +707,6 @@
   <xs:element name="ModifyVolumeRequest" type="tns:modifyVolumeRequest"/>
     
   <xs:element name="ModifyVolumeResponse" type="tns:modifyVolumeResponse"/>
-    
-  <xs:element name="ModifyZimletRequest" type="tns:modifyZimletRequest"/>
-    
-  <xs:element name="ModifyZimletResponse" type="tns:modifyZimletResponse"/>
     
   <xs:element name="MoveBlobsRequest" type="tns:moveBlobsRequest"/>
     
@@ -912,10 +876,6 @@
     
   <xs:element name="SyncGalAccountResponse" type="tns:syncGalAccountResponse"/>
     
-  <xs:element name="UndeployZimletRequest" type="tns:undeployZimletRequest"/>
-    
-  <xs:element name="UndeployZimletResponse" type="tns:undeployZimletResponse"/>
-    
   <xs:element name="UnloadMailboxRequest" type="tns:unloadMailboxRequest"/>
     
   <xs:element name="UnloadMailboxResponse" type="tns:unloadMailboxResponse"/>
@@ -948,10 +908,6 @@
     
   <xs:element name="cos" type="tns:dlInfo"/>
     
-  <xs:element name="include" type="tns:adminZimletInclude"/>
-    
-  <xs:element name="includeCSS" type="tns:adminZimletIncludeCSS"/>
-    
   <xs:element name="mbox" type="tns:mailboxQuotaInfo"/>
     
   <xs:element name="meta" type="tns:adminCustomMetadata"/>
@@ -959,10 +915,6 @@
   <xs:element name="query" type="tns:queueQuery"/>
     
   <xs:element name="server" type="tns:serverInfo"/>
-    
-  <xs:element name="serverExtension" type="tns:zimletServerExtension"/>
-    
-  <xs:element name="target" type="tns:adminZimletTarget"/>
     
   <xs:element name="values" type="tns:statsValueWrapper"/>
     
@@ -2640,30 +2592,6 @@
       
   </xs:complexType>
     
-  <xs:complexType name="configureZimletRequest">
-        
-    <xs:sequence>
-            
-      <xs:element name="content" type="tns:attachmentIdAttrib"/>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="attachmentIdAttrib">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="aid" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="configureZimletResponse">
-        
-    <xs:sequence/>
-      
-  </xs:complexType>
-    
   <xs:complexType name="contactBackupRequest">
         
     <xs:sequence>
@@ -3540,48 +3468,6 @@
       
   </xs:complexType>
     
-  <xs:complexType name="createZimletRequest">
-        
-    <xs:complexContent>
-            
-      <xs:extension base="tns:adminAttrsImpl">
-                
-        <xs:sequence/>
-                
-        <xs:attribute name="name" type="xs:string" use="required"/>
-              
-      </xs:extension>
-          
-    </xs:complexContent>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="createZimletResponse">
-        
-    <xs:sequence>
-            
-      <xs:element name="zimlet" type="tns:zimletInfo"/>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="zimletInfo">
-        
-    <xs:complexContent>
-            
-      <xs:extension base="tns:adminObjectInfo">
-                
-        <xs:sequence/>
-                
-        <xs:attribute name="hasKeyword" type="xs:string"/>
-              
-      </xs:extension>
-          
-    </xs:complexContent>
-      
-  </xs:complexType>
-    
   <xs:complexType name="dedupeBlobsRequest">
         
     <xs:sequence>
@@ -3885,61 +3771,6 @@
   <xs:complexType name="deleteXMbxSearchResponse">
         
     <xs:sequence/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="deleteZimletRequest">
-        
-    <xs:sequence>
-            
-      <xs:element name="zimlet" type="ns1:namedElement"/>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="deleteZimletResponse">
-        
-    <xs:sequence/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="deployZimletRequest">
-        
-    <xs:sequence>
-            
-      <xs:element name="content" type="tns:attachmentIdAttrib"/>
-          
-    </xs:sequence>
-        
-    <xs:attribute name="action" type="xs:string" use="required"/>
-        
-    <xs:attribute name="flush" type="xs:boolean"/>
-        
-    <xs:attribute name="synchronous" type="xs:boolean"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="deployZimletResponse">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="progress" type="tns:zimletDeploymentStatus"/>
-          
-    </xs:sequence>
-      
-    <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-  </xs:complexType>
-    
-  <xs:complexType name="zimletDeploymentStatus">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="server" type="xs:string" use="required"/>
-        
-    <xs:attribute name="status" type="xs:string" use="required"/>
-        
-    <xs:attribute name="error" type="xs:string"/>
       
   </xs:complexType>
     
@@ -4627,188 +4458,6 @@
       
   </xs:complexType>
     
-  <xs:complexType name="getAdminExtensionZimletsRequest">
-        
-    <xs:sequence/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="getAdminExtensionZimletsResponse">
-        
-    <xs:sequence>
-            
-      <xs:element name="zimlets">
-                
-        <xs:complexType>
-                    
-          <xs:sequence>
-                        
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="zimlet" type="tns:adminZimletInfo"/>
-                      
-          </xs:sequence>
-                  
-          <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-        </xs:complexType>
-              
-      </xs:element>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="adminZimletInfo">
-        
-    <xs:sequence>
-            
-      <xs:element minOccurs="0" name="zimletContext" type="tns:adminZimletContext"/>
-            
-      <xs:element minOccurs="0" name="zimlet" type="tns:adminZimletDesc"/>
-            
-      <xs:element minOccurs="0" name="zimletConfig" type="tns:adminZimletConfigInfo"/>
-            
-      <xs:any namespace="##other" processContents="skip"/>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="adminZimletContext">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="baseUrl" type="xs:string" use="required"/>
-        
-    <xs:attribute name="priority" type="xs:int"/>
-        
-    <xs:attribute name="presence" type="xs:string" use="required"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="adminZimletDesc">
-        
-    <xs:sequence>
-            
-      <xs:choice maxOccurs="unbounded" minOccurs="0">
-                
-        <xs:element ref="tns:serverExtension"/>
-                
-        <xs:element ref="tns:include"/>
-                
-        <xs:element ref="tns:includeCSS"/>
-                
-        <xs:element ref="tns:target"/>
-                
-        <xs:any namespace="##other" processContents="skip"/>
-              
-      </xs:choice>
-          
-    </xs:sequence>
-        
-    <xs:attribute name="name" type="xs:string"/>
-        
-    <xs:attribute name="version" type="xs:string"/>
-        
-    <xs:attribute name="description" type="xs:string"/>
-        
-    <xs:attribute name="extension" type="xs:string"/>
-        
-    <xs:attribute name="target" type="xs:string"/>
-        
-    <xs:attribute name="label" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="zimletServerExtension">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="hasKeyword" type="xs:string"/>
-        
-    <xs:attribute name="extensionClass" type="xs:string"/>
-        
-    <xs:attribute name="regex" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:simpleType name="adminZimletInclude">
-        
-    <xs:restriction base="xs:string"/>
-      
-  </xs:simpleType>
-    
-  <xs:simpleType name="adminZimletIncludeCSS">
-        
-    <xs:restriction base="xs:string"/>
-      
-  </xs:simpleType>
-    
-  <xs:simpleType name="adminZimletTarget">
-        
-    <xs:restriction base="xs:string"/>
-      
-  </xs:simpleType>
-    
-  <xs:complexType name="adminZimletConfigInfo">
-        
-    <xs:all>
-            
-      <xs:element minOccurs="0" name="global" type="tns:adminZimletGlobalConfigInfo"/>
-            
-      <xs:element minOccurs="0" name="host" type="tns:adminZimletHostConfigInfo"/>
-          
-    </xs:all>
-        
-    <xs:attribute name="name" type="xs:string"/>
-        
-    <xs:attribute name="version" type="xs:string"/>
-        
-    <xs:attribute name="description" type="xs:string"/>
-        
-    <xs:attribute name="extension" type="xs:string"/>
-        
-    <xs:attribute name="target" type="xs:string"/>
-        
-    <xs:attribute name="label" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="adminZimletGlobalConfigInfo">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="tns:adminZimletProperty"/>
-          
-    </xs:sequence>
-      
-    <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-  </xs:complexType>
-    
-  <xs:complexType name="adminZimletProperty">
-        
-    <xs:simpleContent>
-            
-      <xs:extension base="xs:string">
-                
-        <xs:attribute name="name" type="xs:string"/>
-              
-      </xs:extension>
-          
-    </xs:simpleContent>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="adminZimletHostConfigInfo">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="tns:adminZimletProperty"/>
-          
-    </xs:sequence>
-        
-    <xs:attribute name="name" type="xs:string"/>
-      
-  </xs:complexType>
-    
   <xs:complexType name="getAdminSavedSearchesRequest">
         
     <xs:sequence>
@@ -5426,25 +5075,6 @@
     <xs:sequence>
             
       <xs:element maxOccurs="unbounded" minOccurs="0" name="xmppcomponent" type="tns:xmppComponentInfo"/>
-          
-    </xs:sequence>
-      
-    <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-  </xs:complexType>
-    
-  <xs:complexType name="getAllZimletsRequest">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="exclude" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="getAllZimletsResponse">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="zimlet" type="tns:zimletInfo"/>
           
     </xs:sequence>
       
@@ -7377,89 +7007,6 @@
     <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
   </xs:complexType>
     
-  <xs:complexType name="getZimletRequest">
-        
-    <xs:complexContent>
-            
-      <xs:extension base="ns1:attributeSelectorImpl">
-                
-        <xs:sequence>
-                    
-          <xs:element name="zimlet" type="ns1:namedElement"/>
-                  
-        </xs:sequence>
-              
-      </xs:extension>
-          
-    </xs:complexContent>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="getZimletResponse">
-        
-    <xs:sequence>
-            
-      <xs:element name="zimlet" type="tns:zimletInfo"/>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="getZimletStatusRequest">
-        
-    <xs:sequence/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="getZimletStatusResponse">
-        
-    <xs:sequence>
-            
-      <xs:element name="zimlets" type="tns:zimletStatusParent"/>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="cos" type="tns:zimletStatusCos"/>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="zimletStatusParent">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="zimlet" type="tns:zimletStatus"/>
-          
-    </xs:sequence>
-      
-    <xs:attribute name="unusedCodeGenHelper" type="xs:string"/>
-  </xs:complexType>
-    
-  <xs:complexType name="zimletStatus">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="name" type="xs:string" use="required"/>
-        
-    <xs:attribute name="status" type="tns:zimletStatusSetting" use="required"/>
-        
-    <xs:attribute name="extension" type="xs:boolean" use="required"/>
-        
-    <xs:attribute name="priority" type="xs:int"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="zimletStatusCos">
-        
-    <xs:sequence>
-            
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="zimlet" type="tns:zimletStatus"/>
-          
-    </xs:sequence>
-        
-    <xs:attribute name="name" type="xs:string" use="required"/>
-      
-  </xs:complexType>
-    
   <xs:complexType name="grantRightRequest">
         
     <xs:sequence>
@@ -8183,56 +7730,6 @@
   </xs:complexType>
     
   <xs:complexType name="modifyVolumeResponse">
-        
-    <xs:sequence/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="modifyZimletRequest">
-        
-    <xs:sequence>
-            
-      <xs:element name="zimlet" type="tns:zimletAclStatusPri"/>
-          
-    </xs:sequence>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="zimletAclStatusPri">
-        
-    <xs:sequence>
-            
-      <xs:element minOccurs="0" name="acl" type="tns:zimletAcl"/>
-            
-      <xs:element minOccurs="0" name="status" type="tns:valueAttrib"/>
-            
-      <xs:element minOccurs="0" name="priority" type="tns:integerValueAttrib"/>
-          
-    </xs:sequence>
-        
-    <xs:attribute name="name" type="xs:string" use="required"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="zimletAcl">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="cos" type="xs:string"/>
-        
-    <xs:attribute name="acl" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="integerValueAttrib">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="value" type="xs:int"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="modifyZimletResponse">
         
     <xs:sequence/>
       
@@ -10433,22 +9930,6 @@
       
   </xs:complexType>
     
-  <xs:complexType name="undeployZimletRequest">
-        
-    <xs:sequence/>
-        
-    <xs:attribute name="name" type="xs:string" use="required"/>
-        
-    <xs:attribute name="action" type="xs:string"/>
-      
-  </xs:complexType>
-    
-  <xs:complexType name="undeployZimletResponse">
-        
-    <xs:sequence/>
-      
-  </xs:complexType>
-    
   <xs:complexType name="unloadMailboxRequest">
         
     <xs:sequence>
@@ -10952,18 +10433,6 @@
       <xs:enumeration value="accessedAsc"/>
             
       <xs:enumeration value="accessedDesc"/>
-          
-    </xs:restriction>
-      
-  </xs:simpleType>
-    
-  <xs:simpleType name="zimletStatusSetting">
-        
-    <xs:restriction base="xs:string">
-            
-      <xs:enumeration value="enabled"/>
-            
-      <xs:enumeration value="disabled"/>
           
     </xs:restriction>
       


### PR DESCRIPTION
Updated the carbonio-mailbox wsdl schemas to regenerate the SoapClient correctly.

refs: UM-24