### PR TITLE
fix!: change the format of a returned account locale to xx_YY

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,14 +25,14 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.3.0-1</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>com.zextras.carbonio.user-management</groupId>
       <artifactId>carbonio-user-management-core</artifactId>
-      <version>0.3.0-1</version>
+      <version>0.4.0-SNAPSHOT</version>
     </dependency>
 
     <!-- Guice dependencies -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.3.0-1</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/src/test/java-it/com/zextras/carbonio/user_management/apis/GetMyselfByCookieApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/user_management/apis/GetMyselfByCookieApiIT.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zextras.carbonio.user_management.Simulator;
 import com.zextras.carbonio.user_management.Simulator.SimulatorBuilder;
 import com.zextras.carbonio.user_management.SoapHttpUtils;
-import com.zextras.carbonio.user_management.generated.model.Locale;
 import com.zextras.carbonio.user_management.generated.model.UserMyself;
 import org.assertj.core.api.Assertions;
 import org.eclipse.jetty.http.HttpHeader;
@@ -72,7 +71,7 @@ public class GetMyselfByCookieApiIT {
             "fake@example.com",
             "example.com",
             "Fake Account",
-            "en"
+            "pt_BR"
           )
         ));
 
@@ -96,7 +95,7 @@ public class GetMyselfByCookieApiIT {
     Assertions.assertThat(userMyself.getEmail()).isEqualTo("fake@example.com");
     Assertions.assertThat(userMyself.getDomain()).isEqualTo("example.com");
     Assertions.assertThat(userMyself.getFullName()).isEqualTo("Fake Account");
-    Assertions.assertThat(userMyself.getLocale()).isEqualTo(Locale.EN);
+    Assertions.assertThat(userMyself.getLocale()).isEqualTo("pt_BR");
   }
 
   @Test

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -17,5 +17,5 @@ SPDX-License-Identifier: AGPL-3.0-only
     <appender-ref ref="STDOUT"/>
   </root>
 
-  <logger name="org.mockserver.log.MockServerEventLog" level="INFO"/>
+  <logger name="org.mockserver.log.MockServerEventLog" level="WARN"/>
 </configuration>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.3.0-1</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -7,8 +7,8 @@ targets=(
   "centos"
 )
 pkgname="carbonio-user-management"
-pkgver="0.3.0"
-pkgrel="1"
+pkgver="0.4.0"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio User Management"
 pkgdesclong=(
   "Carbonio User Management"

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.3.0-1</version>
+  <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-user-management</name>

--- a/resources/user-management.yaml
+++ b/resources/user-management.yaml
@@ -234,29 +234,9 @@ components:
         domain:
           type: string
         locale:
-          $ref: '#/components/schemas/Locale'
+          type: string
     UserId:
       type: object
       properties:
         userId:
           type: string
-    Locale:
-      type: string
-      enum:
-        - DE
-        - EN
-        - ES
-        - FR
-        - HI
-        - IT
-        - JA
-        - NL
-        - PL
-        - PT
-        - PT_BR
-        - RO
-        - RU
-        - TH
-        - TR
-        - VI
-        - ZH_CN


### PR DESCRIPTION
When the carbonio-user-management returns the locale (zimbraLocalPref) of a requested account, the string value was returned in upper case (XX_YY) and this raised a problem because the format of this value was unreadable by other systems.

Now the carbonio-user-management returns the locale in the xx_YY format checking if the locale returned by the carbonio-mailbox is a valid one. This check is necessary since the value of this type of pref can be set manually by a sysadmin without any check from the carbonio-mailbox.

When the system receives an invalid locale it falls back to 'en'.

:warning: BREAKING CHANGE: The /users/myself API response is changed to follow the different format used to represent the locale value. Now it is a string (instead of an enumerator) and it can support all the values defined in the standard.

refs: UM-25