### PR TITLE
build(deps): update all dependencies

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.5.1-1</version>
+    <version>0.5.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.5.1-1</version>
+    <version>0.5.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.5.1-1</version>
+    <version>0.5.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-user-management"
-pkgver="0.5.1"
-pkgrel="1"
+pkgver="0.5.2"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio User Management"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.5.1-1</version>
+  <version>0.5.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-user-management</name>

--- a/pom.xml
+++ b/pom.xml
@@ -34,32 +34,32 @@ SPDX-License-Identifier: AGPL-3.0-only
   </modules>
 
   <properties>
-    <assertj.version>3.24.2</assertj.version>
-    <caffeine.version>3.1.6</caffeine.version>
-    <carbonio-mailbox-sdk.version>1.1.0</carbonio-mailbox-sdk.version>
-    <commons-io.version>2.13.0</commons-io.version>
+    <assertj.version>3.25.3</assertj.version>
+    <caffeine.version>3.1.8</caffeine.version>
+    <carbonio-mailbox-sdk.version>1.3.0</carbonio-mailbox-sdk.version>
+    <commons-io.version>2.15.1</commons-io.version>
     <guice.version>6.0.0</guice.version>
-    <jackson.version>2.15.2</jackson.version>
+    <jackson.version>2.16.1</jackson.version>
     <javaee-api.version>8.0.1</javaee-api.version>
-    <jetty-version>10.0.15</jetty-version>
+    <jetty-version>10.0.20</jetty-version>
     <jsonassert.version>1.5.1</jsonassert.version>
-    <junit5.version>5.10.0</junit5.version>
-    <logback-classic.version>1.4.8</logback-classic.version>
+    <junit5.version>5.10.2</junit5.version>
+    <logback-classic.version>1.4.14</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <mockito.version>5.4.0</mockito.version>
+    <mockito.version>5.10.0</mockito.version>
     <resteasy.version>4.7.9.Final</resteasy.version>
-    <swagger-core-version>1.6.11</swagger-core-version>
+    <swagger-core-version>1.6.13</swagger-core-version>
 
     <!-- Plugins -->
-    <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
     <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-    <maven-failsafe.version>3.0.0-M9</maven-failsafe.version>
-    <maven-jacoco.version>0.8.8</maven-jacoco.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-failsafe.version>3.2.5</maven-failsafe.version>
+    <maven-jacoco.version>0.8.11</maven-jacoco.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-surfire.version>3.0.0-M9</maven-surfire.version>
+    <maven-surfire.version>3.2.5</maven-surfire.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <openapi-generator-maven-plugin.version>6.6.0</openapi-generator-maven-plugin.version>
+    <openapi-generator-maven-plugin.version>7.3.0</openapi-generator-maven-plugin.version>
 
     <!-- Other properties -->
     <maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
Dependencies:
 - assertj: 3.24.2 -> 3.25.2
 - caffeine: 3.1.6 -> 3.1.8
 - carbonio-mailbox-sdk: 1.1.0 -> 1.3.0
 - commons-io: 2.13.0 -> 2.15.1
 - jackson: 2.15.2 -> 2.16.1
 - jetty: 10.0.15 -> 10.0.20
 - junit5: 5.10.0 -> 5.10.2
 - logback-classic: 1.4.8 -> 1.4.14
 - mockito: 5.4.0 -> 5.10.0
 - swagger-core: 1.6.11 -> 1.6.13

Plugins:
 - build-helper-maven-plugin: 3.4.0 -> 3.5.0
 - maven-compiler-plugin: 3.11.0 -> 3.12.1
 - maven-failsafe: 3.0.0-M9 -> 3.2.5
 - maven-jacoco: 0.8.8 -> 0.8.11
 - maven-surfire: 3.0.0-M9 -> 3.2.5
 - openapi-generator-maven-plugin: 6.6.0 -> 7.3.0

Refs: UM-28