### PR TITLE
chore(infra): update intentions.json for carbonio-notification-push

### DIFF
--- a/package/intentions.json
+++ b/package/intentions.json
@@ -221,6 +221,29 @@
           }
         }
       ]
+    },
+    {
+      "Name": "carbonio-notification-push",
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/auth/token/",
+            "Methods": [
+              "GET"
+            ]
+          }
+        },
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/health/",
+            "Methods": [
+              "GET"
+            ]
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- In intentions.json, the carbonio-notification-push is added enabling the /auth/token/ and /health/ APIs

refs: UM-29