### PR TITLE
fix: remove package with service in consul

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -42,7 +42,6 @@ sha256sums=(
   "SKIP"
 )
 backup=(
-  "etc/zextras/service-discover/carbonio-user-management.hcl"
   "etc/carbonio/user-management/config.properties"
 )
 
@@ -92,13 +91,13 @@ prerm() {
 
 postrm() {
   rm -Rf /etc/carbonio/user-management/
-  rm -r "${pkgdir}/etc/zextras/service-discover/carbonio-user-management.hcl"
   rm -f /etc/zextras/pending-setups.d/carbonio-user-management.sh
   rm -f /etc/zextras/pending-setups.d/done/carbonio-user-management.sh
 
 
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
-    systemctl reset-failed >/dev/null 2>&1 || :
+    systemctl reset-failed carbonio-user-management-sidecar.service >/dev/null 2>&1 || :
+    systemctl reset-failed carbonio-user-management.service >/dev/null 2>&1 || :
   fi
 }

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -92,10 +92,13 @@ prerm() {
 
 postrm() {
   rm -Rf /etc/carbonio/user-management/
+  rm -r "${pkgdir}/etc/zextras/service-discover/carbonio-user-management.hcl"
   rm -f /etc/zextras/pending-setups.d/carbonio-user-management.sh
   rm -f /etc/zextras/pending-setups.d/done/carbonio-user-management.sh
 
+
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
+    systemctl reset-failed >/dev/null 2>&1 || :
   fi
 }


### PR DESCRIPTION
Enhanced the package removal process with the following commands:
1) Introduced a command to delete the service definition file for the Consul service mesh. The current removal process only deletes /etc/carbonio/user-management/ directory, leaving the service definition intact in the service mesh.

2) Included a command to restart failed systemd services. After stopping and disabling the sidecar service it still exist in the memory of systemd.