### PR TITLE
fix: move jar from /usr/bin to /usr/share to follow the FHS standard

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.6.0-1</version>
+    <version>0.6.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.6.0-1</version>
+    <version>0.6.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.6.0-1</version>
+    <version>0.6.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -19,17 +19,19 @@ depends=(
 )
 source=(
   "carbonio-user-management"
+  "carbonio-user-management-setup"
   "carbonio-user-management.hcl"
   "carbonio-user-management.jar"
   "carbonio-user-management.service"
   "carbonio-user-management-sidecar.service"
-  "carbonio-user-management-setup.sh"
+  "carbonio-user-management-pending-setup"
   "config.properties"
   "intentions.json"
   "policies.json"
   "service-protocol.json"
 )
 sha256sums=(
+  "SKIP"
   "SKIP"
   "SKIP"
   "SKIP"
@@ -49,11 +51,12 @@ backup=(
 package() {
   cd "${srcdir}"
   install -Dm 755 carbonio-user-management "${pkgdir}/usr/bin/carbonio-user-management"
-  install -Dm 755 carbonio-user-management.jar "${pkgdir}/usr/bin/carbonio/user-management/carbonio-user-management.jar"
+  install -Dm 755 carbonio-user-management-setup "${pkgdir}/usr/bin/carbonio-user-management-setup"
+  install -Dm 755 carbonio-user-management.jar "${pkgdir}/usr/share/carbonio/carbonio-user-management.jar"
   install -Dm 644 carbonio-user-management.service "${pkgdir}/lib/systemd/system/carbonio-user-management.service"
   install -Dm 644 carbonio-user-management-sidecar.service "${pkgdir}/lib/systemd/system/carbonio-user-management-sidecar.service"
   install -Dm 644 carbonio-user-management.hcl "${pkgdir}/etc/zextras/service-discover/carbonio-user-management.hcl"
-  install -Dm 644 carbonio-user-management-setup.sh "${pkgdir}/etc/zextras/pending-setups.d/carbonio-user-management.sh"
+  install -Dm 644 carbonio-user-management-pending-setup "${pkgdir}/etc/zextras/pending-setups.d/carbonio-user-management.sh"
   install -Dm 644 intentions.json "${pkgdir}/etc/carbonio/user-management/service-discover/intentions.json"
   install -Dm 644 policies.json "${pkgdir}/etc/carbonio/user-management/service-discover/policies.json"
   install -Dm 644 service-protocol.json "${pkgdir}/etc/carbonio/user-management/service-discover/service-protocol.json"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-user-management"
-pkgver="0.6.0"
-pkgrel="1"
+pkgver="0.6.1"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio User Management"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -19,10 +19,10 @@ depends=(
 )
 source=(
   "carbonio-user-management"
-  "carbonio-user-management-setup"
   "carbonio-user-management.hcl"
   "carbonio-user-management.jar"
   "carbonio-user-management.service"
+  "carbonio-user-management-setup"
   "carbonio-user-management-sidecar.service"
   "carbonio-user-management-pending-setup"
   "config.properties"
@@ -31,17 +31,17 @@ source=(
   "service-protocol.json"
 )
 sha256sums=(
+  "9321fd4f460b35c8643591a270eda07decb89aca89dcb210b1e03d88db297f61"
+  "f06c46b16c9b64ba3689d98a8e751c7ef7679bee6c927efc0ee926e61cc0cc5d"
   "SKIP"
-  "SKIP"
-  "SKIP"
-  "SKIP"
-  "SKIP"
-  "SKIP"
-  "SKIP"
-  "SKIP"
-  "SKIP"
-  "SKIP"
-  "SKIP"
+  "dae97efb72fc78bf9c2cf61f4306a3ee4ac686e30863218a16ea3431f8b1c759"
+  "786c6ea505fa5bffc23a5189a3035b19c392d3224901a079f710363efb6de7e8"
+  "aa36152fe2cc9ef96fa874c14b4510a3828bef055c8c0fa16437066d8707bd41"
+  "41e10587c1f04ef0a1d53608bc2ca94bb520177b0f39f42433cfae3e279c96a8"
+  "6988430e5876d8284e973c69ff5525fad5d089ce46687918503518487a086feb"
+  "1a58295f74dbcd34925394d1d3c4b906426759a41c754288dc01fbce971ab126"
+  "d4413a87bd9d2ec97799b31639d7ff539f9b91d0162468db09017b92b322dfc8"
+  "beae6d6f2e9d1ef926039319e5d9d2fb06ee07ac41bc445414be93443570c809"
 )
 backup=(
   "etc/zextras/service-discover/carbonio-user-management.hcl"

--- a/package/carbonio-user-management
+++ b/package/carbonio-user-management
@@ -1,75 +1,13 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-if [[ $(id -u) -ne 0 ]]; then
-  echo "Please run as root"
-  exit 1
-fi
-
-if [[ "$1" != "setup" ]]; then
-  echo "Syntax: 'carbonio-user-management setup' to automatically configure the service"
-  exit 1;
-fi
-
-# Decrypt the bootstrap token, asking the password to the sys admin
-# --setup check for SETUP_CONSUL_TOKEN env. variable and uses it
-# to avoid re-asking for the password
-echo -n "Insert the cluster credential password: "
-export CONSUL_HTTP_TOKEN=$(service-discover bootstrap-token --setup)
-EXIT_CODE="$?"
-echo ""
-if [[ "${EXIT_CODE}" != "0" ]]; then
-  echo "Cannot access to bootstrap token"
-  exit 1;
-fi
-# Limit secret visibility as much as possible
-export -n SETUP_CONSUL_TOKEN
-
-POLICY_NAME='carbonio-user-management-policy'
-POLICY_DESCRIPTION='User Management service policy for service and sidecar proxy'
-
-# create or update policy for the specific service (this will be shared across cluster)
-consul acl policy create -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules @/etc/carbonio/user-management/service-discover/policies.json >/dev/null 2>&1
-if [[ "$?" != "0" ]]; then
-    consul acl policy update -no-merge -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules @/etc/carbonio/user-management/service-discover/policies.json
-    if [[ "$?" != "0" ]]; then
-      echo "Setup failed: Cannot update policy for ${POLICY_NAME}"
-      exit 1
-    fi
-fi
-
-# Declare the service as http
-consul config write /etc/carbonio/user-management/service-discover/service-protocol.json
-
-# Allow other services to contact this service
-consul config write /etc/carbonio/user-management/service-discover/intentions.json
-
-if [[ ! -f "/etc/carbonio/user-management/service-discover/token" ]]; then
-    # Create the token
-    consul acl token create -format json -policy-name "${POLICY_NAME}" -description "Token for
-    carobonio-user-management/$(hostname -A)" |
-      jq -r '.SecretID' > /etc/carbonio/user-management/service-discover/token;
-    chown carbonio-user-management:carbonio-user-management /etc/carbonio/user-management/service-discover/token
-    chmod 0600 /etc/carbonio/user-management/service-discover/token
-
-    # To pass the token to consul-template we need to inject it to a env. variable
-    # since it doesn't accept a file as an argument
-    mkdir -p /etc/systemd/system/carbonio-user-management.service.d/
-    cat >/etc/systemd/system/carbonio-user-management.service.d/override.conf <<EOF
-[Service]
-Environment="CONSUL_HTTP_TOKEN=$(cat /etc/carbonio/user-management/service-discover/token)"
-EOF
-    chmod 0600 /etc/systemd/system/carbonio-user-management.service.d/override.conf
-    systemctl daemon-reload
-fi
-
-consul reload
-
-# Limit token visibility as much as possible
-export -n CONSUL_HTTP_TOKEN
-
-systemctl restart carbonio-user-management.service
-systemctl restart carbonio-user-management-sidecar.service
+JAVA_HOME="/usr/share/carbonio/user-management:/opt/zextras/common/lib/jvm/java"
+export JAVA_HOME
+/opt/zextras/common/bin/java \
+  -Djava.net.preferIPv4Stack=true \
+  -Xmx1024m \
+  -Xms1024m \
+  -jar /usr/share/carbonio/carbonio-user-management.jar

--- a/package/carbonio-user-management-pending-setup
+++ b/package/carbonio-user-management-pending-setup
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-carbonio-user-management setup
+carbonio-user-management-setup

--- a/package/carbonio-user-management-setup
+++ b/package/carbonio-user-management-setup
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+if [[ $(id -u) -ne 0 ]]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+# Decrypt the bootstrap token, asking the password to the sys admin
+# --setup check for SETUP_CONSUL_TOKEN env. variable and uses it
+# to avoid re-asking for the password
+echo -n "Insert the cluster credential password: "
+export CONSUL_HTTP_TOKEN=$(service-discover bootstrap-token --setup)
+EXIT_CODE="$?"
+echo ""
+if [[ "${EXIT_CODE}" != "0" ]]; then
+  echo "Cannot access to bootstrap token"
+  exit 1;
+fi
+# Limit secret visibility as much as possible
+export -n SETUP_CONSUL_TOKEN
+
+POLICY_NAME='carbonio-user-management-policy'
+POLICY_DESCRIPTION='User Management service policy for service and sidecar proxy'
+
+# create or update policy for the specific service (this will be shared across cluster)
+consul acl policy create -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules @/etc/carbonio/user-management/service-discover/policies.json >/dev/null 2>&1
+if [[ "$?" != "0" ]]; then
+    consul acl policy update -no-merge -name "${POLICY_NAME}" -description "${POLICY_DESCRIPTION}" -rules @/etc/carbonio/user-management/service-discover/policies.json
+    if [[ "$?" != "0" ]]; then
+      echo "Setup failed: Cannot update policy for ${POLICY_NAME}"
+      exit 1
+    fi
+fi
+
+# Declare the service as http
+consul config write /etc/carbonio/user-management/service-discover/service-protocol.json
+
+# Allow other services to contact this service
+consul config write /etc/carbonio/user-management/service-discover/intentions.json
+
+if [[ ! -f "/etc/carbonio/user-management/service-discover/token" ]]; then
+    # Create the token
+    consul acl token create -format json -policy-name "${POLICY_NAME}" -description "Token for
+    carobonio-user-management/$(hostname -A)" |
+      jq -r '.SecretID' > /etc/carbonio/user-management/service-discover/token;
+    chown carbonio-user-management:carbonio-user-management /etc/carbonio/user-management/service-discover/token
+    chmod 0600 /etc/carbonio/user-management/service-discover/token
+
+    # To pass the token to consul-template we need to inject it to a env. variable
+    # since it doesn't accept a file as an argument
+    mkdir -p /etc/systemd/system/carbonio-user-management.service.d/
+    cat >/etc/systemd/system/carbonio-user-management.service.d/override.conf <<EOF
+[Service]
+Environment="CONSUL_HTTP_TOKEN=$(cat /etc/carbonio/user-management/service-discover/token)"
+EOF
+    chmod 0600 /etc/systemd/system/carbonio-user-management.service.d/override.conf
+    systemctl daemon-reload
+fi
+
+consul reload
+
+# Limit token visibility as much as possible
+export -n CONSUL_HTTP_TOKEN
+
+systemctl restart carbonio-user-management.service
+systemctl restart carbonio-user-management-sidecar.service

--- a/package/carbonio-user-management.service
+++ b/package/carbonio-user-management.service
@@ -10,11 +10,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/zextras/common/bin/java \
-  -Djava.net.preferIPv4Stack=true \
-  -Xmx1024m \
-  -Xms1024m \
-  -jar /usr/bin/carbonio/user-management/carbonio-user-management.jar
+ExecStart=/usr/bin/carbonio-user-management
 
 User=carbonio-user-management
 Group=carbonio-user-management

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.6.0-1</version>
+  <version>0.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-user-management</name>


### PR DESCRIPTION
- Updated PKGBUILD to install jar under /usr/share/carbonio
- Renamed setup scripts and created a separated script to launch jar instead of launching it directly from service

Refs: UM-33