### PR TITLE
feat: add cache for getUserMyself response

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.6.0-1</version>
+    <version>0.6.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.6.0-1</version>
+    <version>0.6.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/src/main/java/com/zextras/carbonio/user_management/cache/CacheManager.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/cache/CacheManager.java
@@ -11,14 +11,16 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.zextras.carbonio.user_management.entities.UserToken;
 import com.zextras.carbonio.user_management.generated.model.UserInfo;
+import com.zextras.carbonio.user_management.generated.model.UserMyself;
 import java.util.concurrent.TimeUnit;
 
 @Singleton
 public class CacheManager {
 
-  private final Cache<String, UserInfo>  userByIdCache;
-  private final Cache<String, UserInfo>  userByEmailCache;
-  private final Cache<String, UserToken> userTokenCache;
+  private final Cache<String, UserInfo>   userByIdCache;
+  private final Cache<String, UserInfo>   userByEmailCache;
+  private final Cache<String, UserToken>  userTokenCache;
+  private final Cache<String, UserMyself> userMyselfCache;
 
   @Inject
   public CacheManager() {
@@ -66,6 +68,11 @@ public class CacheManager {
         }
       })
       .build();
+
+    userMyselfCache = Caffeine
+      .newBuilder()
+      .expireAfterWrite(15, TimeUnit.MINUTES)
+      .build();
   }
 
   public Cache<String, UserInfo> getUserByIdCache() {
@@ -78,5 +85,9 @@ public class CacheManager {
 
   public Cache<String, UserToken> getUserTokenCache() {
     return userTokenCache;
+  }
+
+  public Cache<String, UserMyself> getUserMyselfCache() {
+    return userMyselfCache;
   }
 }

--- a/core/src/main/java/com/zextras/carbonio/user_management/cache/CacheManager.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/cache/CacheManager.java
@@ -69,10 +69,7 @@ public class CacheManager {
       })
       .build();
 
-    userMyselfCache = Caffeine
-      .newBuilder()
-      .expireAfterWrite(15, TimeUnit.MINUTES)
-      .build();
+    userMyselfCache = Caffeine.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
   }
 
   public Cache<String, UserInfo> getUserByIdCache() {

--- a/core/src/main/java/com/zextras/carbonio/user_management/cache/CacheManager.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/cache/CacheManager.java
@@ -69,7 +69,10 @@ public class CacheManager {
       })
       .build();
 
-    userMyselfCache = Caffeine.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
+    userMyselfCache = Caffeine
+      .newBuilder()
+      .expireAfterWrite(5, TimeUnit.MINUTES)
+      .build();
   }
 
   public Cache<String, UserInfo> getUserByIdCache() {

--- a/core/src/main/java/com/zextras/carbonio/user_management/entities/UserToken.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/entities/UserToken.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 public class UserToken {
 
   private final String token;
-  private final String   userId;
+  private final String userId;
   private final Long   lifeTimeInMillis;
 
   public UserToken(

--- a/core/src/main/java/com/zextras/carbonio/user_management/services/UserService.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/services/UserService.java
@@ -12,7 +12,11 @@ import com.sun.xml.ws.fault.ServerSOAPFaultException;
 import com.zextras.carbonio.user_management.cache.CacheManager;
 import com.zextras.carbonio.user_management.entities.UserToken;
 import com.zextras.carbonio.user_management.exceptions.ServiceException;
-import com.zextras.carbonio.user_management.generated.model.*;
+import com.zextras.carbonio.user_management.generated.model.UserId;
+import com.zextras.carbonio.user_management.generated.model.UserInfo;
+import com.zextras.carbonio.user_management.generated.model.UserMyself;
+import com.zextras.carbonio.user_management.generated.model.UserStatus;
+import com.zextras.carbonio.user_management.generated.model.UserType;
 import com.zextras.mailbox.client.requests.Request;
 import com.zextras.mailbox.client.service.InfoRequests.Sections;
 import com.zextras.mailbox.client.service.ServiceClient;
@@ -34,7 +38,7 @@ public class UserService {
 
   private static final Logger logger = LoggerFactory.getLogger(UserService.class);
 
-  private final CacheManager cacheManager;
+  private final CacheManager  cacheManager;
   private final ServiceClient mailboxClient;
 
   @Inject
@@ -52,30 +56,30 @@ public class UserService {
     userInfo.setStatus(UserStatus.CLOSED);
 
     accountInfo
-        .getAttr()
-        .forEach(
-            attribute -> {
-              if (attribute.getName().equals("displayName")) {
-                userInfo.setFullName(attribute.getValue());
-              }
+      .getAttr()
+      .forEach(
+        attribute -> {
+          if (attribute.getName().equals("displayName")) {
+            userInfo.setFullName(attribute.getValue());
+          }
 
-              if (attribute.getName().equals("zimbraId")) {
-                UserId userId = new UserId();
-                userId.setUserId(attribute.getValue());
-                userInfo.setId(userId);
-              }
+          if (attribute.getName().equals("zimbraId")) {
+            UserId userId = new UserId();
+            userId.setUserId(attribute.getValue());
+            userInfo.setId(userId);
+          }
 
-              if (attribute.getName().equals("zimbraAccountStatus")) {
-                userInfo.setStatus(UserStatus.valueOf(attribute.getValue().toUpperCase()));
-              }
+          if (attribute.getName().equals("zimbraAccountStatus")) {
+            userInfo.setStatus(UserStatus.valueOf(attribute.getValue().toUpperCase()));
+          }
 
-              if (attribute.getName().equals("zimbraIsExternalVirtualAccount")) {
-                userInfo.setType(
-                    Boolean.parseBoolean(attribute.getValue().toLowerCase())
-                        ? UserType.GUEST
-                        : UserType.INTERNAL);
-              }
-            });
+          if (attribute.getName().equals("zimbraIsExternalVirtualAccount")) {
+            userInfo.setType(
+              Boolean.parseBoolean(attribute.getValue().toLowerCase())
+                ? UserType.GUEST
+                : UserType.INTERNAL);
+          }
+        });
 
     userInfo.setEmail(accountInfo.getName());
     userInfo.setDomain(accountInfo.getPublicURL());
@@ -85,35 +89,35 @@ public class UserService {
 
   public Response getUsers(List<String> userIds, String token) {
     return Response.ok()
-        .entity(
-            userIds.stream()
-                .distinct()
-                .map(
-                    userId -> {
-                      System.out.println("Requested: " + userId);
-                      UserInfo userInfo = cacheManager.getUserByIdCache().getIfPresent(userId);
+      .entity(
+        userIds.stream()
+          .distinct()
+          .map(
+            userId -> {
+              System.out.println("Requested: " + userId);
+              UserInfo userInfo = cacheManager.getUserByIdCache().getIfPresent(userId);
 
-                      if (userInfo == null) {
-                        try {
-                          final Request<ZcsPortType, GetAccountInfoResponse> request =
-                              AccountInfo.byId(userId).withAuthToken(token);
-                          final GetAccountInfoResponse accountInfo = mailboxClient.send(request);
+              if (userInfo == null) {
+                try {
+                  final Request<ZcsPortType, GetAccountInfoResponse> request =
+                    AccountInfo.byId(userId).withAuthToken(token);
+                  final GetAccountInfoResponse accountInfo = mailboxClient.send(request);
 
-                          userInfo = createUserInfo(accountInfo);
-                          cacheManager.getUserByIdCache().put(userId, userInfo);
-                          cacheManager.getUserByEmailCache().put(userInfo.getEmail(), userInfo);
-                          System.out.println("Found: " + userId);
-                        } catch (Exception e) {
-                          logger.error(
-                              "GetUsers with userId {} and token {} falied: {}", userId, token, e);
-                        }
-                      }
+                  userInfo = createUserInfo(accountInfo);
+                  cacheManager.getUserByIdCache().put(userId, userInfo);
+                  cacheManager.getUserByEmailCache().put(userInfo.getEmail(), userInfo);
+                  System.out.println("Found: " + userId);
+                } catch (Exception e) {
+                  logger.error(
+                    "GetUsers with userId {} and token {} falied: {}", userId, token, e);
+                }
+              }
 
-                      return userInfo;
-                    })
-                .filter(Objects::nonNull)
-                .toList())
-        .build();
+              return userInfo;
+            })
+          .filter(Objects::nonNull)
+          .toList())
+      .build();
   }
 
   public Response getInfoById(String userId, String token) {
@@ -123,7 +127,7 @@ public class UserService {
     if (userInfo == null) {
       try {
         final Request<ZcsPortType, GetAccountInfoResponse> request =
-            AccountInfo.byId(userId).withAuthToken(token);
+          AccountInfo.byId(userId).withAuthToken(token);
         final GetAccountInfoResponse accountInfo = mailboxClient.send(request);
 
         userInfo = createUserInfo(accountInfo);
@@ -149,7 +153,7 @@ public class UserService {
     if (userInfo == null) {
       try {
         final Request<ZcsPortType, GetAccountInfoResponse> request =
-            AccountInfo.byEmail(userEmail).withAuthToken(token);
+          AccountInfo.byEmail(userEmail).withAuthToken(token);
         final GetAccountInfoResponse accountInfo = mailboxClient.send(request);
 
         userInfo = createUserInfo(accountInfo);
@@ -158,11 +162,11 @@ public class UserService {
 
       } catch (ServerSOAPFaultException e) {
         logger.error(
-            "GetInfoByEmail with user email {} and token {} failed: {}", userEmail, token, e);
+          "GetInfoByEmail with user email {} and token {} failed: {}", userEmail, token, e);
         return Response.status(Status.NOT_FOUND).build();
       } catch (Exception e) {
         logger.error(
-            "GetInfoByEmail with user email {} and token {} failed: {}", userEmail, token, e);
+          "GetInfoByEmail with user email {} and token {} failed: {}", userEmail, token, e);
         return Response.status(Status.INTERNAL_SERVER_ERROR).build();
       }
     }
@@ -171,74 +175,81 @@ public class UserService {
   }
 
   public Optional<UserMyself> getMyselfByToken(String token) {
-    try {
-      final Request<ZcsPortType, GetInfoResponse> request =
-          Info.sections(Sections.children, Sections.attrs, Sections.prefs).withAuthToken(token);
-      final GetInfoResponse infoResponse = mailboxClient.send(request);
+    System.out.println("Requested: " + token);
+    UserMyself userMyself = cacheManager.getUserMyselfCache().getIfPresent(token);
 
-      UserId userId = new UserId();
-      userId.setUserId(infoResponse.getId());
-
-      // This old style try/catch is necessary because:
-      //  - the system cannot trust the user locale since it can be set manually by the sysadmin
-      //    and there is no check if the value is a valid one. So the LocaleUtils#toLocale method
-      //    can raise an exception if the Locale is malformed.
-      //  - the project doesn't have the Vavr dependency containing the Try construct to handle the
-      //    exception in a cleaner way and I don't want to add it now only for this.
-      Locale locale;
+    if (userMyself == null) {
       try {
-        locale =
+        final Request<ZcsPortType, GetInfoResponse> request =
+          Info.sections(Sections.children, Sections.attrs, Sections.prefs).withAuthToken(token);
+        final GetInfoResponse infoResponse = mailboxClient.send(request);
+
+        UserId userId = new UserId();
+        userId.setUserId(infoResponse.getId());
+
+        // This old style try/catch is necessary because:
+        //  - the system cannot trust the user locale since it can be set manually by the sysadmin
+        //    and there is no check if the value is a valid one. So the LocaleUtils#toLocale method
+        //    can raise an exception if the Locale is malformed.
+        //  - the project doesn't have the Vavr dependency containing the Try construct to handle the
+        //    exception in a cleaner way and I don't want to add it now only for this.
+        Locale locale;
+        try {
+          locale =
             infoResponse.getPrefs().getPref().stream()
-                .filter(perf -> perf.getName().equals("zimbraPrefLocale"))
-                .findFirst()
-                .map(pref -> LocaleUtils.toLocale(pref.getValue()))
-                .orElse(Locale.ENGLISH);
-      } catch (IllegalArgumentException exception) {
-        logger.error(
+              .filter(perf -> perf.getName().equals("zimbraPrefLocale"))
+              .findFirst()
+              .map(pref -> LocaleUtils.toLocale(pref.getValue()))
+              .orElse(Locale.ENGLISH);
+        } catch (IllegalArgumentException exception) {
+          logger.error(
             "The user id {} has a locale with an invalid format. The system falls back in '{}'",
             userId.getUserId(),
             Locale.ENGLISH);
 
-        locale = Locale.ENGLISH;
-      }
+          locale = Locale.ENGLISH;
+        }
 
-      String fullName =
+        String fullName =
           infoResponse.getAttrs().getAttr().stream()
-              .filter(attribute -> attribute.getName().equals("displayName"))
+            .filter(attribute -> attribute.getName().equals("displayName"))
+            .findFirst()
+            .map(Attr::getValue)
+            .orElse("");
+
+        UserType userType =
+          Boolean.parseBoolean(
+            infoResponse.getAttrs().getAttr().stream()
+              .filter(
+                attribute -> attribute.getName().equals("zimbraIsExternalVirtualAccount"))
               .findFirst()
               .map(Attr::getValue)
-              .orElse("");
+              .orElse("FALSE") // default value, will be translated to type internal
+              .toLowerCase())
+            ? UserType.GUEST
+            : UserType.INTERNAL;
 
-      UserType userType =
-          Boolean.parseBoolean(
-                  infoResponse.getAttrs().getAttr().stream()
-                      .filter(
-                          attribute -> attribute.getName().equals("zimbraIsExternalVirtualAccount"))
-                      .findFirst()
-                      .map(Attr::getValue)
-                      .orElse("FALSE") // default value, will be translated to type internal
-                      .toLowerCase())
-              ? UserType.GUEST
-              : UserType.INTERNAL;
+        userMyself = new UserMyself();
+        userMyself.setId(userId);
+        userMyself.setEmail(infoResponse.getName());
+        userMyself.setDomain(infoResponse.getPublicURL());
+        userMyself.setFullName(fullName);
+        userMyself.setLocale(locale.toString());
+        userMyself.setType(userType);
 
-      UserMyself userMyself = new UserMyself();
-      userMyself.setId(userId);
-      userMyself.setEmail(infoResponse.getName());
-      userMyself.setDomain(infoResponse.getPublicURL());
-      userMyself.setFullName(fullName);
-      userMyself.setLocale(locale.toString());
-      userMyself.setType(userType);
+        cacheManager.getUserMyselfCache().put(token, userMyself);
 
-      return Optional.of(userMyself);
-
-    } catch (ServerSOAPFaultException exception) {
-      logger.error("GetMyselfByToken with token {} failed: {}", token, exception);
-      return Optional.empty();
-    } catch (Exception exception) {
-      logger.error("GetMyselfByToken with token {} failed: {}", token, exception);
-      throw new ServiceException(
+      } catch (ServerSOAPFaultException exception) {
+        logger.error("GetMyselfByToken with token {} failed: {}", token, exception);
+        return Optional.empty();
+      } catch (Exception exception) {
+        logger.error("GetMyselfByToken with token {} failed: {}", token, exception);
+        throw new ServiceException(
           "Unable to get account user info due to an internal service error");
+      }
     }
+
+    return Optional.of(userMyself);
   }
 
   public Response validateUserToken(String token) {
@@ -250,7 +261,7 @@ public class UserService {
     if (userToken == null) {
       try {
         final Request<ZcsPortType, GetInfoResponse> request =
-            Info.sections(Sections.children).withAuthToken(token);
+          Info.sections(Sections.children).withAuthToken(token);
         final GetInfoResponse infoResponse = mailboxClient.send(request);
 
         userToken = new UserToken(token, infoResponse.getId(), infoResponse.getLifetime());

--- a/core/src/test/java-it/com/zextras/carbonio/user_management/apis/GetMyselfByCookieApiIT.java
+++ b/core/src/test/java-it/com/zextras/carbonio/user_management/apis/GetMyselfByCookieApiIT.java
@@ -25,7 +25,7 @@ import org.mockserver.client.MockServerClient;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
-public class GetMyselfByCookieApiIT {
+class GetMyselfByCookieApiIT {
 
   static Simulator simulator;
 

--- a/core/src/test/java-ut/com/zextras/carbonio/user_management/controllers/UsersApiControllerTest.java
+++ b/core/src/test/java-ut/com/zextras/carbonio/user_management/controllers/UsersApiControllerTest.java
@@ -6,7 +6,6 @@ package com.zextras.carbonio.user_management.controllers;
 
 import com.zextras.carbonio.user_management.exceptions.ServiceException;
 import com.zextras.carbonio.user_management.generated.NotFoundException;
-import com.zextras.carbonio.user_management.generated.model.UserInfo;
 import com.zextras.carbonio.user_management.generated.model.UserMyself;
 import com.zextras.carbonio.user_management.services.UserService;
 
@@ -22,7 +21,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class UsersApiControllerTest {
+class UsersApiControllerTest {
 
   static UsersApiController usersApiController;
   static UserService userServiceMock;

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.6.0-1</version>
+    <version>0.6.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-user-management"
-pkgver="0.6.0"
-pkgrel="1"
+pkgver="0.6.1"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio User Management"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.6.0-1</version>
+  <version>0.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-user-management</name>


### PR DESCRIPTION
The purpose of this cache is to optimize the response time for multiple getUserMyself API calls made with the same token within a short period. This is particularly beneficial for clients who frequently use this API, as it helps prevent the mailbox from becoming overloaded with heavy requests.

refs: UM-35