### PR TITLE
build(deps): updated dependencies

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.7.0-1</version>
+    <version>0.7.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.7.0-1</version>
+    <version>0.7.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/generated/pom.xml
+++ b/generated/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.user-management</groupId>
     <artifactId>carbonio-user-management</artifactId>
-    <version>0.7.0-1</version>
+    <version>0.7.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-user-management"
-pkgver="0.7.0"
-pkgrel="1"
+pkgver="0.7.1"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio User Management"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <groupId>com.zextras.carbonio.user-management</groupId>
   <artifactId>carbonio-user-management</artifactId>
-  <version>0.7.0-1</version>
+  <version>0.7.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>carbonio-user-management</name>
@@ -34,32 +34,32 @@ SPDX-License-Identifier: AGPL-3.0-only
   </modules>
 
   <properties>
-    <assertj.version>3.25.3</assertj.version>
+    <assertj.version>3.26.3</assertj.version>
     <caffeine.version>3.1.8</caffeine.version>
     <carbonio-mailbox-sdk.version>1.5.0</carbonio-mailbox-sdk.version>
-    <commons-io.version>2.15.1</commons-io.version>
-    <guice.version>6.0.0</guice.version>
-    <jackson.version>2.16.1</jackson.version>
+    <commons-io.version>2.16.1</commons-io.version>
+    <guice.version>7.0.0</guice.version>
+    <jackson.version>2.17.2</jackson.version>
     <javaee-api.version>8.0.1</javaee-api.version>
-    <jetty-version>10.0.20</jetty-version>
-    <jsonassert.version>1.5.1</jsonassert.version>
-    <junit5.version>5.10.2</junit5.version>
-    <logback-classic.version>1.4.14</logback-classic.version>
+    <jetty-version>12.0.12</jetty-version>
+    <jsonassert.version>1.5.3</jsonassert.version>
+    <junit5.version>5.11.0</junit5.version>
+    <logback-classic.version>1.5.7</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <mockito.version>5.10.0</mockito.version>
-    <resteasy.version>4.7.9.Final</resteasy.version>
-    <swagger-core-version>1.6.13</swagger-core-version>
+    <mockito.version>5.13.0</mockito.version>
+    <resteasy.version>6.2.10.Final</resteasy.version>
+    <swagger-core-version>2.2.22</swagger-core-version>
 
     <!-- Plugins -->
-    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
-    <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
-    <maven-failsafe.version>3.2.5</maven-failsafe.version>
-    <maven-jacoco.version>0.8.11</maven-jacoco.version>
-    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-surfire.version>3.2.5</maven-surfire.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
+    <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <maven-failsafe.version>3.5.0</maven-failsafe.version>
+    <maven-jacoco.version>0.8.12</maven-jacoco.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+    <maven-surfire.version>3.3.1</maven-surfire.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <openapi-generator-maven-plugin.version>7.3.0</openapi-generator-maven-plugin.version>
+    <openapi-generator-maven-plugin.version>7.8.0</openapi-generator-maven-plugin.version>
 
     <!-- Other properties -->
     <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.2</jackson.version>
     <javaee-api.version>8.0.1</javaee-api.version>
-    <jetty-version>10.0.24</jetty-version>
+    <jetty-version>10.0.20</jetty-version>
     <jsonassert.version>1.5.3</jsonassert.version>
     <junit5.version>5.11.0</junit5.version>
     <logback-classic.version>1.5.7</logback-classic.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.2</jackson.version>
     <javaee-api.version>8.0.1</javaee-api.version>
-    <jetty-version>11.0.24</jetty-version>
+    <jetty-version>10.0.24</jetty-version>
     <jsonassert.version>1.5.3</jsonassert.version>
     <junit5.version>5.11.0</junit5.version>
     <logback-classic.version>1.5.7</logback-classic.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@ SPDX-License-Identifier: AGPL-3.0-only
     <caffeine.version>3.1.8</caffeine.version>
     <carbonio-mailbox-sdk.version>1.5.0</carbonio-mailbox-sdk.version>
     <commons-io.version>2.16.1</commons-io.version>
-    <guice.version>7.0.0</guice.version>
+    <guice.version>6.0.0</guice.version>
     <jackson.version>2.17.2</jackson.version>
     <javaee-api.version>8.0.1</javaee-api.version>
-    <jetty-version>10.0.20</jetty-version>
+    <jetty-version>10.0.24</jetty-version>
     <jsonassert.version>1.5.3</jsonassert.version>
     <junit5.version>5.11.0</junit5.version>
     <logback-classic.version>1.5.7</logback-classic.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,14 @@ SPDX-License-Identifier: AGPL-3.0-only
     <guice.version>7.0.0</guice.version>
     <jackson.version>2.17.2</jackson.version>
     <javaee-api.version>8.0.1</javaee-api.version>
-    <jetty-version>12.0.12</jetty-version>
+    <jetty-version>11.0.24</jetty-version>
     <jsonassert.version>1.5.3</jsonassert.version>
     <junit5.version>5.11.0</junit5.version>
     <logback-classic.version>1.5.7</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
     <mockito.version>5.13.0</mockito.version>
-    <resteasy.version>6.2.10.Final</resteasy.version>
-    <swagger-core-version>2.2.22</swagger-core-version>
+    <resteasy.version>4.7.9.Final</resteasy.version>
+    <swagger-core-version>1.6.14</swagger-core-version>
 
     <!-- Plugins -->
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
Updated all dependencies and plugins versions to the current one:
- assertj: 3.25.3 -> 3.26.3
- commons-io: 2.15.1 -> 2.16.1
- jackson: 2.16.1 -> 2.17.2
- jetty: 10.0.20 -> 10.0.24
- jsonassert: 1.5.1 -> 1.5.3
- junit5: 5.10.2 -> 5.11.0
- logback-classic: 1.4.14 -> 1.5.7
- mockito: 5.10.0 -> 5.13.0
- swagger-core: 1.6.13 -> 1.6.14

- build-helper-maven-plugin: 3.5.0 -> 3.6.0
- maven-assembly-plugin: 3.6.0 -> 3.7.1
- maven-compiler-plugin: 3.12.1 -> 3.13.0
- maven-failsafe: 3.2.5 -> 3.5.0
- maven-jacoco: 0.8.11 -> 0.8.12
- maven-jar-plugin: 3.3.0 -> 3.4.2
- maven-surefire: 3.2.5 -> 3.3.1
- openapi-generator-maven-plugin: 7.3.0 -> 7.8.0

Refs: UM-37