### PR TITLE
build(deps): update carbonio-mailbox-sdk to version 1.9.0

### DIFF
--- a/core/src/main/java/com/zextras/carbonio/user_management/services/UserService.java
+++ b/core/src/main/java/com/zextras/carbonio/user_management/services/UserService.java
@@ -20,7 +20,7 @@ import com.zextras.mailbox.client.MailboxServerException;
 import com.zextras.mailbox.client.requests.Request;
 import com.zextras.mailbox.client.service.InfoRequests.Sections;
 import com.zextras.mailbox.client.service.ServiceClient;
-import https.www_zextras_com.wsdl.zimbraservice.ZcsPortType;
+import com.zextras.wsdl.zimbraservice.ZcsPortType;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <properties>
     <assertj.version>3.26.3</assertj.version>
     <caffeine.version>3.1.8</caffeine.version>
-    <carbonio-mailbox-sdk.version>1.5.0</carbonio-mailbox-sdk.version>
+    <carbonio-mailbox-sdk.version>1.9.0</carbonio-mailbox-sdk.version>
     <commons-io.version>2.16.1</commons-io.version>
     <guice.version>6.0.0</guice.version>
     <jackson.version>2.17.2</jackson.version>


### PR DESCRIPTION
- Updated carbonio-mailbox-sdk version
- Replaced ZcsPortType import to align it with the SDK

See https://github.com/zextras/carbonio-mailbox-sdk/pull/50 and https://github.com/zextras/carbonio-mailbox-sdk/pull/52

Refs: UM-38