### PR TITLE
chore: migrate Jenkinsfile to jenkins-lib-common@1.1.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,11 @@ library(
 )
 
 library(
-    identifier: 'jenkins-packages-build-library@1.0.4',
+    identifier: 'jenkins-lib-common@1.1.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
-        credentialsId: 'jenkins-integration-with-github-account'
+        credentialsId: 'jenkins-integration-with-github-account',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
     ])
 )
 
@@ -40,9 +40,6 @@ pipeline {
     }
 
     parameters {
-        booleanParam defaultValue: false,
-            description: 'Whether to upload the packages in playground repositories',
-            name: 'PLAYGROUND'
         booleanParam(
             name: 'PREPARE_RELEASE',
             defaultValue: false,
@@ -60,15 +57,13 @@ pipeline {
         )
     }
 
-    tools {
-        jfrog 'jfrog-cli'
-    }
-
     stages {
-        stage('Checkout') {
+        stage('Setup') {
             steps {
+                checkout scm
                 script {
-                    checkoutWithMetadata()
+                    gitMetadata()
+                    properties(defaultPipelineProperties())
                 }
             }
         }
@@ -163,9 +158,15 @@ pipeline {
         }
 
         stage('Upload artifacts') {
+            when {
+                expression { return uploadStage.shouldUpload() }
+            }
+            tools {
+                jfrog 'jfrog-cli'
+            }
             steps {
                 uploadStage(
-                    packages: yapHelper.getPackageNames(),
+                    packages: yapHelper.resolvePackageNames(),
                     rockySinglePkg: true,
                     ubuntuSinglePkg: true
                 )
@@ -218,19 +219,16 @@ pipeline {
             }
         }
 
-        stage('Build and Publish Docker Image') {
-            when {
-                not {
-                    expression { env.BRANCH_NAME.startsWith('PR-') }
-                }
-            }
+        stage('Publish docker images') {
             steps {
-                buildAndPublishDockerImage(
-                    projectName: 'carbonio-user-management',
+                dockerStage([
                     dockerfile: 'docker/minimal/carbonio-user-management/Dockerfile',
-                    imageTitle: 'Carbonio User Management',
-                    imageDescription: 'Carbonio User Management'
-                )
+                    imageName: 'carbonio-user-management',
+                    ocLabels: [
+                        title: 'Carbonio User Management',
+                        description: 'Carbonio User Management Service',
+                    ]
+                ])
             }
         }
     }


### PR DESCRIPTION
Migrates Jenkinsfile from deprecated `jenkins-packages-build-library@1.0.4` to `jenkins-lib-common@1.1.2`.

## Changes

- **Library migration**: Updated to `jenkins-lib-common@1.1.2` from `jenkins-packages-build-library@1.0.4`
- **Parameters cleanup**: Removed unused `PLAYGROUND` parameter
- **Setup stage enhancement**: Renamed `Checkout` → `Setup` and added `properties(defaultPipelineProperties())` call
- **Tool scoping**: Moved `jfrog` tool declaration from pipeline-level to `Upload artifacts` stage

```groovy
// Before: global tools declaration
pipeline {
    tools {
        jfrog 'jfrog-cli'
    }
}

// After: stage-scoped tool
stage('Upload artifacts') {
    tools {
        jfrog 'jfrog-cli'
    }
    steps { ... }
}
```

Resolve: [IN-959](https://zextras.atlassian.net/browse/IN-959)

[IN-959]: https://zextras.atlassian.net/browse/IN-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ