### PR TITLE
fix(docker): generate proper config.properties

### DIFF
--- a/docker/minimal/carbonio-user-management/Dockerfile
+++ b/docker/minimal/carbonio-user-management/Dockerfile
@@ -6,14 +6,6 @@ RUN mkdir -p /etc/carbonio/user-management
 
 COPY ../../boot/target/carbonio-user-management-*-jar-with-dependencies.jar .
 
-CMD sh -c 'echo "\n\
-carbonio.user-management.host=${CARBONIO_USER_MANAGEMENT_HOST}\n\
-carbonio.user-management.port=${CARBONIO_USER_MANAGEMENT_PORT}\n\
-\n\
-carbonio.mailbox.host=${CARBONIO_MAILBOX_HOST}\n\
-carbonio.mailbox.port=${CARBONIO_MAILBOX_PORT}" > /etc/carbonio/user-management/config.properties && \
-JAR=$(ls carbonio-user-management-*-jar-with-dependencies.jar | head -n 1) && \
-java -Djava.net.preferIPv4Stack=true \
-     -Xms1024m \
-     -Xmx2048m \
-     -jar "$JAR"'
+COPY docker/minimal/carbonio-user-management/entrypoint.sh entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/minimal/carbonio-user-management/entrypoint.sh
+++ b/docker/minimal/carbonio-user-management/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+echo "" > /etc/carbonio/user-management/config.properties
+
+addEnvToProperties() {
+  if [ -n "$2" ];
+  then echo "$1=$2" >> /etc/carbonio/user-management/config.properties;
+  else echo "$1 is not set. Skipping it.";
+  fi
+}
+
+addEnvToProperties "carbonio.user-management.host" "${CARBONIO_USER_MANAGEMENT_HOST}"
+addEnvToProperties "carbonio.user-management.port" "${CARBONIO_USER_MANAGEMENT_PORT}"
+
+addEnvToProperties "carbonio.mailbox.host" "${CARBONIO_MAILBOX_HOST}"
+addEnvToProperties "carbonio.mailbox.port" "${CARBONIO_MAILBOX_PORT}"
+
+JAR=$(ls carbonio-user-management-*-jar-with-dependencies.jar | head -n 1)
+
+exec java -Djava.net.preferIPv4Stack=true \
+     -Xms1024m \
+     -Xmx2048m \
+     -jar "$JAR"


### PR DESCRIPTION
The source of config.properties not expanding correctly is because we recently moved from openjdk-17-slim, which was based on Debian.
In eclipse-temurin we are using sh and echo does produce "\n", causing the issue in config.properties.

Moved to entrypoint (same as tasks and files)