### PR TITLE
build: upgrade JDK from 17 to 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
                         profile = '-P prod'
                     }
 
-                    container('jdk-17') {
+                    container('jdk-21') {
                         sh """
                             mvn -B package ${profile}
                             cp boot/target/carbonio-user-management-*-jar-with-dependencies.jar \
@@ -97,7 +97,7 @@ pipeline {
                 expression { params.SKIP_TESTS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P run-unit-tests'
                 }
             }
@@ -108,7 +108,7 @@ pipeline {
                 expression { params.SKIP_TESTS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P run-integration-tests'
                 }
             }
@@ -119,7 +119,7 @@ pipeline {
                 expression { params.SKIP_CHECKS == false }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     sh 'mvn -B verify -P generate-jacoco-full-report'
                     recordCoverage(
                         tools: [[parser: 'JACOCO']],
@@ -140,7 +140,7 @@ pipeline {
                }
             }
             steps {
-                container('jdk-17') {
+                container('jdk-21') {
                     withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
                         sh 'mvn -B sonar:sonar'
                     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -220,9 +220,15 @@ SPDX-License-Identifier: AGPL-3.0-only
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surfire.version}</version>
+        <version>${maven-surefire.version}</version>
         <configuration>
-          <skipTests>${skip.unit.tests}</skipTests>
+            <skipTests>${skip.unit.tests}</skipTests>
+            <argLine>
+                -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+            </argLine>
+            <systemPropertyVariables>
+                <slf4j.provider>ch.qos.logback.classic.spi.LogbackServiceProvider</slf4j.provider>
+            </systemPropertyVariables>
         </configuration>
       </plugin>
 

--- a/docker/minimal/carbonio-user-management/Dockerfile
+++ b/docker/minimal/carbonio-user-management/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <junit5.version>5.11.0</junit5.version>
     <logback-classic.version>1.5.7</logback-classic.version>
     <mock-server.version>5.15.0</mock-server.version>
-    <mockito.version>5.13.0</mockito.version>
+    <mockito.version>5.20.0</mockito.version>
     <resteasy.version>4.7.9.Final</resteasy.version>
     <swagger-core-version>1.6.14</swagger-core-version>
 
@@ -61,13 +61,13 @@ SPDX-License-Identifier: AGPL-3.0-only
     <maven-failsafe.version>3.5.0</maven-failsafe.version>
     <maven-jacoco.version>0.8.12</maven-jacoco.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-    <maven-surfire.version>3.3.1</maven-surfire.version>
+    <maven-surefire.version>3.5.4</maven-surefire.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <openapi-generator-maven-plugin.version>7.8.0</openapi-generator-maven-plugin.version>
 
     <!-- Other properties -->
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <maven.version.ignore>(?i).*-(alpha|beta|m|rc)([-.]?\d+)?</maven.version.ignore>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -196,6 +196,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         <artifactId>carbonio-mailbox-sdk</artifactId>
         <version>${carbonio-mailbox-sdk.version}</version>
       </dependency>
+
       <dependency>
         <groupId>jakarta.activation</groupId>
         <artifactId>jakarta.activation-api</artifactId>


### PR DESCRIPTION
- Upgrade mockito version from 5.13.0 to 5.20.0
- Upgrade maven-surefire-plugin version from 3.3.1 to 3.5.4
- Update Java version to 21 in pom.xml files
- Configure Mockito agent for JDK 21 compatibility
- Update maven-surefire-plugin configuration
- Set slf4j provider in the maven-surefire-plugin to solve warning in tests

ref: CO-2825