### PR TITLE
chore: migrate to unified dt3_pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ library(
     ])
 )
 
-dt3_quarkusPipeline(
+dt3_pipeline(
     repoName: 'carbonio-user-management',
     sdk: [module: 'sdk'],
     jarBuild: [jarName: 'carbonio-user-management.jar'],


### PR DESCRIPTION
## Summary
- Replace `dt3_quarkusPipeline` with `dt3_pipeline` (unified pipeline)
- No functional change — same stages, same behavior

## Test plan
- [x] Jenkins build SUCCESS (build #1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)