### PR TITLE
chore(sidecar): use parent image entrypoint and just override setup script

### DIFF
--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -17,10 +17,10 @@ COPY package/policies.json         /etc/carbonio/user-management/service-discove
 # App jar (used for --setup only)
 COPY app/target/*-runner.jar /usr/share/carbonio/carbonio-user-management.jar
 
-COPY docker/sidecar/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+# Setup script wrapper
+COPY docker/sidecar/carbonio-user-management-setup /usr/local/bin/carbonio-user-management-setup
+RUN chmod +x /usr/local/bin/carbonio-user-management-setup
 
 ENV SERVICE_NAME=carbonio-user-management
 ENV TOKEN_FILE=/etc/carbonio/user-management/service-discover/token
-
-ENTRYPOINT ["entrypoint.sh"]
+ENV SETUP_SCRIPT="carbonio-user-management-setup setup"

--- a/docker/sidecar/carbonio-user-management-setup
+++ b/docker/sidecar/carbonio-user-management-setup
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+if [ "$1" = "setup" ]; then
+  export SETUP_CONSUL_TOKEN="${CONSUL_HTTP_TOKEN:-00000000-0000-0000-0000-000000000000}"
+  java -jar /usr/share/carbonio/carbonio-user-management.jar --setup "${CONSUL_HTTP_ADDR:-http://127.0.0.1:8500}"
+  unset SETUP_CONSUL_TOKEN
+fi

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname="carbonio-user-management"
 pkgver="0.0.0"
-pkgrel="wip.12.85613ccf"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio User Management"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname="carbonio-user-management"
 pkgver="0.0.0"
-pkgrel="SNAPSHOT"
+pkgrel="wip.12.85613ccf"
 pkgdesc="Carbonio User Management"
 maintainer="Zextras <packages@zextras.com>"
 arch=('x86_64')


### PR DESCRIPTION
Using base image flow, we can apply the same logic to all containers.
Currently the base image also copies the token to /shared, so apps can mount tokens under /shared without shadowing /etc/carbonio.

This allows using the sidecar in a deny default policy on Consul + containers and test acl, intentions and policies are working as intended