### PR TITLE
perf: [CO-3523] define otel service name and version

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -94,6 +94,7 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   Quarkus - JSON-P - Runtime (io.quarkus:quarkus-jsonp:3.27.2)
   Quarkus - Mutiny - Runtime (io.quarkus:quarkus-mutiny:3.27.2)
   Quarkus - Netty - Runtime (io.quarkus:quarkus-netty:3.27.2)
+  Quarkus - OpenTelemetry - Runtime (io.quarkus:quarkus-opentelemetry:3.27.2)
   Quarkus - REST - Common - Runtime (io.quarkus:quarkus-rest-common:3.27.2)
   Quarkus - REST - Jackson - Runtime (io.quarkus:quarkus-rest-jackson:3.27.2)
   Quarkus - REST - Jackson Common Bits - Runtime (io.quarkus:quarkus-rest-jackson-common:3.27.2)
@@ -110,6 +111,7 @@ Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
   Quarkus - Vert.x - Runtime (io.quarkus:quarkus-vertx:3.27.2)
   Quarkus - Vert.x Late Bound MDC Provider (io.quarkus:quarkus-vertx-latebound-mdc-provider:3.27.2)
   Quarkus - Virtual Threads - Runtime (io.quarkus:quarkus-virtual-threads:3.27.2)
+  Quarkus - WebSockets Next - SPI (io.quarkus:quarkus-websockets-next-spi:3.27.2)
   quarkus-security (io.quarkus.security:quarkus-security:2.2.1)
   RESTEasy Reactive - Common Runtime (io.quarkus.resteasy.reactive:resteasy-reactive-common:3.27.2)
   RESTEasy Reactive - Common Types (io.quarkus.resteasy.reactive:resteasy-reactive-common-types:3.27.2)
@@ -275,6 +277,28 @@ MIT-0 (https://spdx.org/licenses/MIT-0.html) applies to:
 The Apache License, Version 2.0 (https://spdx.org/licenses/The Apache License, Version 2.0.html) applies to:
 
   JSpecify annotations (org.jspecify:jspecify:1.0.0)
+  OpenTelemetry Instrumentation for Java (io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.10.0)
+  OpenTelemetry Instrumentation for Java (io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support:2.10.0-alpha)
+  OpenTelemetry Instrumentation for Java (io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.10.0)
+  OpenTelemetry Instrumentation for Java (io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:2.10.0-alpha)
+  OpenTelemetry Instrumentation for Java (io.opentelemetry.instrumentation:opentelemetry-jdbc:2.10.0-alpha)
+  OpenTelemetry Instrumentation for Java (io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java17:2.10.0-alpha)
+  OpenTelemetry Instrumentation for Java (io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8:2.10.0-alpha)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-api:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-api-incubator:1.44.1-alpha)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-context:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-exporter-common:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-exporter-otlp:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-exporter-otlp-common:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-sdk:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-sdk-common:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-sdk-logs:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-sdk-metrics:1.44.1)
+  OpenTelemetry Java (io.opentelemetry:opentelemetry-sdk-trace:1.44.1)
+  OpenTelemetry Semantic Conventions Java (io.opentelemetry.semconv:opentelemetry-semconv:1.28.0-alpha)
+  OpenTelemetry Semantic Conventions Java (io.opentelemetry.semconv:opentelemetry-semconv-incubating:1.29.0-alpha)
   Woodstox (com.fasterxml.woodstox:woodstox-core:7.0.0)
 
 The BSD 2-Clause License (https://spdx.org/licenses/The BSD 2-Clause License.html) applies to:
@@ -283,6 +307,6 @@ The BSD 2-Clause License (https://spdx.org/licenses/The BSD 2-Clause License.htm
 
 Unknown license (https://spdx.org/licenses/Unknown license.html) applies to:
 
-  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-wip.10.e0f6b27a)
+  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-wip.18.42747def)
   carbonio-mailbox-sdk (com.zextras:carbonio-mailbox-sdk:1.16.0)
 

--- a/app/docs/openapi.json.license
+++ b/app/docs/openapi.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -90,6 +90,12 @@ SPDX-License-Identifier: AGPL-3.0-only
       <artifactId>caffeine</artifactId>
     </dependency>
 
+    <!-- OpenTelemetry -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-opentelemetry</artifactId>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -5,7 +5,6 @@
 carbonio.service.name=carbonio-user-management
 
 quarkus.otel.sdk.disabled=true
-quarkus.otel.mp.compatibility=true
 quarkus.otel.traces.enabled=true
 quarkus.otel.metrics.enabled=true
 quarkus.otel.logs.enabled=true

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -6,6 +6,9 @@ carbonio.service.name=carbonio-user-management
 
 quarkus.otel.sdk.disabled=true
 quarkus.otel.mp.compatibility=true
+quarkus.otel.traces.enabled=true
+quarkus.otel.metrics.enabled=true
+quarkus.otel.logs.enabled=true
 
 networking-config.carbonio.service.host=127.78.0.5
 networking-config.carbonio.service.port=10000

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 carbonio.service.name=carbonio-user-management
+quarkus.application.name=carbonio-user-management
 
 quarkus.otel.sdk.disabled=true
 quarkus.otel.traces.enabled=true

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -4,6 +4,9 @@
 
 carbonio.service.name=carbonio-user-management
 
+quarkus.otel.sdk.disabled=true
+quarkus.otel.mp.compatibility=true
+
 networking-config.carbonio.service.host=127.78.0.5
 networking-config.carbonio.service.port=10000
 


### PR DESCRIPTION
## Changes
- allows instrumenting with default name 
- uses quarkus.application.name, because pom.xml name is "carbonio-user-management-app"
- user can turn otel on or of, both VM or container
- projects using quarkus could use idiomatic way -> uses maven version by default, requires quarkus-opentelemetry

See: https://quarkus.io/guides/opentelemetry

## How to use

Set these environment variables. Default protocol is grpc for Quarkus

```      env:
        - name: QUARKUS_OTEL_SDK_DISABLED
          value: "false"
        - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
          value: "http://carbonio-monitoring:4317"
```
---

## Differences between Quarkus Otel SDK and Otel Java Agent 

I've found few issues with Quarkus vs java agent, mainly on configuration:
- cannot set "otlp" exporters with quarkus opentelemetry exporter (e.g.:    OTEL_LOGS_EXPORTER="otlp") -> throws unsupported. It actually can export otlp, it's just a configuration matter. See: https://quarkus.io/guides/opentelemetry#the-default
- by default export of metrics and logs is off, only traces is true. The setting is read at **BUILD** time. So if we want to switch off one the application must be rebuilt (Quarkus philosophy). We can actually suppress the exporter, but it will still keep tracking things internally, it won't just export.
- OTEL_ env do not work even with https://quarkus.io/guides/opentelemetry#quarkus-opentelemetry_quarkus-otel-mp-compatibility (you need to set quarkus)
- we might need to upgrade quarkus beacuse export of traces fails completely against grafana lgtm: https://github.com/quarkusio/quarkus/discussions/42937 (works only with grpc at port 4317)

---
Works with (against grafana lgtm):
```      env:
        - name: QUARKUS_OTEL_SDK_DISABLED
          value: "false"
        - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
          value: "http://carbonio-monitoring:4317"
```

Does not work with

```
        - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
          value: "http://carbonio-monitoring:4318"
        - name: QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL
          value: "http/protobuf"


 2026-04-17 16:24:27,851 WARNING [io.qua.ope.run.exp.otl.sen.VertxHttpSender] (vert.x-eventloop-thread-3) Failed to export                 
  LogsRequestMarshaler. The request could not be executed. Full error message: carbonio-monitoring
```
despite being supported