### PR TITLE
chore(deps): bump sdk-parent to 1.8.2-1

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -1,10 +1,10 @@
 AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
-  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.8.1-1)
-  Carbonio Quarkus Extensions - gRPC SDK Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-grpc-sdk:1.8.1-1)
-  Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.8.1-1)
+  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.8.2-1)
+  Carbonio Quarkus Extensions - gRPC SDK Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-grpc-sdk:1.8.2-1)
+  Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.8.2-1)
   Carbonio Systemd Notify (com.zextras.carbonio:carbonio-systemd-notify:1.0.1)
-  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-wip.22.ebd0160b)
+  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-wip.23.61769c4c)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -54,17 +54,17 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-grpc-sdk</artifactId>
-      <version>1.8.1-1</version>
+      <version>1.8.2-1</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-rest</artifactId>
-      <version>1.8.1-1</version>
+      <version>1.8.2-1</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.8.1-1</version>
+      <version>1.8.2-1</version>
     </dependency>
 
     <!-- SDK gRPC stubs -->
@@ -111,7 +111,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.8.1-1</version>
+      <version>1.8.2-1</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -54,17 +54,17 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-grpc-sdk</artifactId>
-      <version>1.8.2-1</version>
+      <version>${carbonio-quarkus-extensions.version}</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-rest</artifactId>
-      <version>1.8.2-1</version>
+      <version>${carbonio-quarkus-extensions.version}</version>
     </dependency>
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.8.2-1</version>
+      <version>${carbonio-quarkus-extensions.version}</version>
     </dependency>
 
     <!-- SDK gRPC stubs -->
@@ -111,7 +111,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>com.zextras.carbonio.quarkus</groupId>
       <artifactId>carbonio-quarkus-extensions-bootstrap</artifactId>
-      <version>1.8.2-1</version>
+      <version>${carbonio-quarkus-extensions.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- Dependencies -->
     <assertj.version>3.27.7</assertj.version>
     <carbonio-mailbox-sdk.version>1.17.1</carbonio-mailbox-sdk.version>
+    <carbonio-quarkus-extensions.version>1.8.2-1</carbonio-quarkus-extensions.version>
 
     <!-- Plugins -->
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   <parent>
     <groupId>com.zextras.carbonio.quarkus</groupId>
     <artifactId>carbonio-quarkus-extensions-sdk-parent</artifactId>
-    <version>1.8.1-1</version>
+    <version>1.8.2-1</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
## Summary
- Bumps `carbonio-quarkus-extensions-sdk-parent` from `1.8.1-1` to `1.8.2-1`
- Picks up protobuf-java 4.33.2 pin in the SDK parent, ensuring compiler and runtime protobuf versions stay in sync

## Context
The SDK parent was compiling with protoc 4.33.2 but consumers could resolve protobuf-java 3.25.x at runtime, causing `NoClassDefFoundError: RuntimeVersion$RuntimeDomain`. The new parent version pins protobuf-java to match protoc.

## Test plan
- [ ] Jenkins build passes (tests + packaging)
- [ ] Published SDK artifact resolves protobuf-java 4.33.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)