### PR TITLE
chore: update carbonio-sidecar base image from latest to devel

### DIFF
--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:devel
 
 RUN apt-get update && apt-get install -y openjdk-21-jre-headless && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Update the sidecar base image tag from `carbonio-sidecar:latest` to `carbonio-sidecar:devel` in the sidecar Dockerfile(s).

## Test plan
- [ ] CI build of the sidecar image(s) succeeds
- [ ] Sidecar container starts and registers with consul as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)