### PR TITLE
feat(ci): [IN-951] add arm64 platform to docker image builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,10 +26,12 @@ dt3_pipeline(
     docker: [
         [dockerfile: 'docker/Dockerfile',
          imageName: 'carbonio-user-management',
+         platforms: ['linux/amd64', 'linux/arm64'] as Set,
          title: 'Carbonio User Management',
          description: 'Carbonio User Management Service'],
         [dockerfile: 'docker/sidecar/Dockerfile',
          imageName: 'carbonio-user-management-sidecar',
+         platforms: ['linux/amd64', 'linux/arm64'] as Set,
          title: 'Carbonio User Management Sidecar',
          description: 'Carbonio User Management Sidecar Service'],
     ],

--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -4,7 +4,7 @@ AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
   Carbonio Quarkus Extensions - gRPC SDK Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-grpc-sdk:1.8.2-1)
   Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.8.2-1)
   Carbonio Systemd Notify (com.zextras.carbonio:carbonio-systemd-notify:1.0.1)
-  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.0.3-wip.23.61769c4c)
+  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.1.1-wip.1.fa63c5b5)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,18 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
+# Create the runtime config dir in a BUILDPLATFORM prep stage so the final
+# image needs no target-arch RUN (a RUN in the TARGETPLATFORM stage would
+# require QEMU => exec format error on arm64 cross-builds).
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-alpine AS prep
+RUN mkdir -p /out/etc/carbonio/user-management
+
 FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 
-RUN mkdir -p /etc/carbonio/user-management
+# Empty runtime config dir, created QEMU-free above.
+COPY --from=prep /out/etc /etc
 
 COPY app/target/*-runner.jar carbonio-user-management.jar
 

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -2,9 +2,19 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
+# The setup jar needs a JRE. Installing openjdk-21-jre-headless via apt in the
+# final stage runs target-arch maintainer scripts (no QEMU => exec format error
+# on arm64). Instead, pull the JRE from the official multi-arch eclipse-temurin
+# jammy image (glibc, matches the ubuntu-jammy carbonio-sidecar base); buildx
+# selects the arch-matched layer, so no target-arch RUN and no QEMU.
+FROM eclipse-temurin:21-jre-jammy AS jre
+
 FROM registry.dev.zextras.com/dev/carbonio-sidecar:devel
 
-RUN apt-get update && apt-get install -y openjdk-21-jre-headless && rm -rf /var/lib/apt/lists/*
+# Arch-matched JRE copied from the multi-arch temurin image (QEMU-free).
+COPY --from=jre /opt/java/openjdk /opt/java/openjdk
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH="/opt/java/openjdk/bin:${PATH}"
 
 # Service registration
 COPY package/carbonio-user-management.hcl /consul/config/
@@ -17,9 +27,8 @@ COPY package/policies.json         /etc/carbonio/user-management/service-discove
 # App jar (used for --setup only)
 COPY app/target/*-runner.jar /usr/share/carbonio/carbonio-user-management.jar
 
-# Setup script wrapper
-COPY docker/sidecar/carbonio-user-management-setup /usr/local/bin/carbonio-user-management-setup
-RUN chmod +x /usr/local/bin/carbonio-user-management-setup
+# Setup script wrapper (COPY --chmod avoids a target-arch RUN — QEMU-free)
+COPY --chmod=755 docker/sidecar/carbonio-user-management-setup /usr/local/bin/carbonio-user-management-setup
 
 ENV SERVICE_NAME=carbonio-user-management
 ENV TOKEN_FILE=/etc/carbonio/user-management/service-discover/token


### PR DESCRIPTION
Adds arm64 multi-arch support (JVM service, arch-independent). **Depends on jenkins-lib-common#108** (forwards per-image `platforms` through `dt3_pipeline`). Main Dockerfile: `mkdir` moved to a $BUILDPLATFORM prep stage. Sidecar: replaced `apt-get install openjdk-21-jre-headless` (target-arch maintainer scripts => QEMU) with `COPY --from=eclipse-temurin:21-jre-jammy` (multi-arch, arch-matched JRE), and `RUN chmod` => `COPY --chmod`. `platforms: [...] as Set` added to both docker entries.