### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -4,7 +4,7 @@ AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
   Carbonio Quarkus Extensions - gRPC SDK Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-grpc-sdk:1.8.2-1)
   Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.8.2-1)
   Carbonio Systemd Notify (com.zextras.carbonio:carbonio-systemd-notify:1.0.1)
-  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.1.1-wip.1.fa63c5b5)
+  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.1.1-wip.1.54e5e239)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,10 +5,10 @@
 # Create the runtime config dir in a BUILDPLATFORM prep stage so the final
 # image needs no target-arch RUN (a RUN in the TARGETPLATFORM stage would
 # require QEMU => exec format error on arm64 cross-builds).
-FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-alpine AS prep
+FROM --platform=$BUILDPLATFORM docker.io/library/eclipse-temurin:21-jdk-alpine AS prep
 RUN mkdir -p /out/etc/carbonio/user-management
 
-FROM eclipse-temurin:21-jdk-alpine
+FROM docker.io/library/eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 

--- a/docker/packaging/Dockerfile
+++ b/docker/packaging/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM alpine:3.22.1 AS prep
+FROM docker.io/library/alpine:3.22.1 AS prep
 WORKDIR /staging
 COPY ../../. .
 
@@ -40,7 +40,7 @@ COPY --from=prep /staging .
 RUN yap build rocky-9 /tmp/staging/
 
 # Final stage
-FROM alpine:3.22.1 AS final
+FROM docker.io/library/alpine:3.22.1 AS final
 WORKDIR /output
 
 COPY --from=ubuntu-focal-builder /tmp/staging/artifacts ./ubuntu-focal/

--- a/docker/sidecar/Dockerfile
+++ b/docker/sidecar/Dockerfile
@@ -7,7 +7,7 @@
 # on arm64). Instead, pull the JRE from the official multi-arch eclipse-temurin
 # jammy image (glibc, matches the ubuntu-jammy carbonio-sidecar base); buildx
 # selects the arch-matched layer, so no target-arch RUN and no QEMU.
-FROM eclipse-temurin:21-jre-jammy AS jre
+FROM docker.io/library/eclipse-temurin:21-jre-jammy AS jre
 
 FROM registry.dev.zextras.com/dev/carbonio-sidecar:devel
 


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.