### PR TITLE
fix: derive guest/internal type from isExternalVirtualAccount

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -4,7 +4,7 @@ AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
   Carbonio Quarkus Extensions - gRPC SDK Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-grpc-sdk:1.8.2-1)
   Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.8.2-1)
   Carbonio Systemd Notify (com.zextras.carbonio:carbonio-systemd-notify:1.0.1)
-  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.1.1-wip.1.54e5e239)
+  Carbonio User Management - gRPC SDK (com.zextras.carbonio.user-management:carbonio-user-management-grpc-sdk:1.1.1-wip.1.548e3e2e)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:
 
@@ -294,5 +294,5 @@ The BSD 2-Clause License (https://spdx.org/licenses/The BSD 2-Clause License.htm
 
 Unknown license (https://spdx.org/licenses/Unknown license.html) applies to:
 
-  carbonio-mailbox-sdk (com.zextras:carbonio-mailbox-sdk:1.17.1)
+  carbonio-mailbox-sdk (com.zextras:carbonio-mailbox-sdk:1.18.0)
 

--- a/app/docs/configs.md
+++ b/app/docs/configs.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 # Default Configuration
 
 ## Networking Config

--- a/app/docs/openapi.yaml
+++ b/app/docs/openapi.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-only
-
 ---
 openapi: 3.1.0
 paths:

--- a/app/src/main/java/com/zextras/carbonio/user_management/service/UserService.java
+++ b/app/src/main/java/com/zextras/carbonio/user_management/service/UserService.java
@@ -311,7 +311,7 @@ public class UserService {
         info.displayName() != null ? info.displayName() : "",
         info.domain() != null ? info.domain() : "",
         info.status() != null ? info.status().name().toUpperCase() : "ACTIVE",
-        info.isExternal() ? "GUEST" : "INTERNAL"
+        info.isExternalVirtualAccount() ? "GUEST" : "INTERNAL"
     );
   }
 
@@ -329,7 +329,7 @@ public class UserService {
         info.displayName() != null ? info.displayName() : "",
         info.domain() != null ? info.domain() : "",
         info.status() != null ? info.status().name().toUpperCase() : "ACTIVE",
-        info.isExternal() ? "GUEST" : "INTERNAL",
+        info.isExternalVirtualAccount() ? "GUEST" : "INTERNAL",
         info.locale() != null ? info.locale() : Locale.ENGLISH.toString(),
         features,
         info.capabilities() != null ? info.capabilities() : Map.of()

--- a/app/src/test/java/com/zextras/carbonio/user_management/service/UserServiceCoalesceTest.java
+++ b/app/src/test/java/com/zextras/carbonio/user_management/service/UserServiceCoalesceTest.java
@@ -52,7 +52,7 @@ class UserServiceCoalesceTest {
 
   private AccountInfo accountInfo(String userId, String email) {
     return new AccountInfo(userId, email, "Test User", "cos-1", "dom-1",
-        "example.com", AccountStatus.active, false, false, "en",
+        "example.com", AccountStatus.active, false, false, false, "en",
         Map.of(), Map.of(), null);
   }
 

--- a/app/src/test/java/com/zextras/carbonio/user_management/service/UserServiceMappingTest.java
+++ b/app/src/test/java/com/zextras/carbonio/user_management/service/UserServiceMappingTest.java
@@ -38,9 +38,10 @@ class UserServiceMappingTest {
   }
 
   private AccountInfo accountInfo(String id, String name, String displayName, String domain,
-      AccountStatus status, boolean isExternal) {
+      AccountStatus status, boolean isExternalVirtualAccount) {
     return new AccountInfo(id, name, displayName, "cos-1", "dom-1",
-        domain, status, false, isExternal, "en", Map.of(), Map.of(), 3_600_000L);
+        domain, status, false, false, isExternalVirtualAccount, "en", Map.of(), Map.of(),
+        3_600_000L);
   }
 
   @Nested
@@ -72,9 +73,23 @@ class UserServiceMappingTest {
     }
 
     @Test
-    void mapsInternalWhenNotExternal() {
+    void mapsInternalWhenNotExternalVirtualAccount() {
       AccountInfo info = accountInfo("uid-1", "user@example.com", "User",
           "example.com", AccountStatus.active, false);
+
+      UserInfo result = userService.mapAccountInfoToUserInfo(info);
+
+      assertThat(result.type()).isEqualTo("INTERNAL");
+    }
+
+    @Test
+    void usesIsExternalVirtualAccountNotIsExternal() {
+      // Regression for CO-3822: the guest/internal distinction must be driven by
+      // isExternalVirtualAccount (zimbraIsExternalVirtualAccount), NOT by isExternal
+      // (which reflects mail-transport routing). An account routed externally but that
+      // is not a virtual/guest account must still map to INTERNAL.
+      AccountInfo info = new AccountInfo("uid-1", "user@example.com", "User", "cos-1", "dom-1",
+          "example.com", AccountStatus.active, false, true, false, "en", Map.of(), Map.of(), null);
 
       UserInfo result = userService.mapAccountInfoToUserInfo(info);
 
@@ -104,7 +119,7 @@ class UserServiceMappingTest {
     @Test
     void nullDisplayNameBecomesEmptyString() {
       AccountInfo info = new AccountInfo("uid-1", "user@example.com", null, "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, "en", Map.of(), Map.of(), null);
+          "example.com", AccountStatus.active, false, false, false, "en", Map.of(), Map.of(), null);
 
       UserInfo result = userService.mapAccountInfoToUserInfo(info);
 
@@ -114,7 +129,7 @@ class UserServiceMappingTest {
     @Test
     void nullDomainBecomesEmptyString() {
       AccountInfo info = new AccountInfo("uid-1", "user@example.com", "User", "cos-1", "dom-1",
-          null, AccountStatus.active, false, false, "en", Map.of(), Map.of(), null);
+          null, AccountStatus.active, false, false, false, "en", Map.of(), Map.of(), null);
 
       UserInfo result = userService.mapAccountInfoToUserInfo(info);
 
@@ -124,7 +139,7 @@ class UserServiceMappingTest {
     @Test
     void nullStatusDefaultsToActive() {
       AccountInfo info = new AccountInfo("uid-1", "user@example.com", "User", "cos-1", "dom-1",
-          "example.com", null, false, false, "en", Map.of(), Map.of(), null);
+          "example.com", null, false, false, false, "en", Map.of(), Map.of(), null);
 
       UserInfo result = userService.mapAccountInfoToUserInfo(info);
 
@@ -139,7 +154,7 @@ class UserServiceMappingTest {
     void mapsAllBasicFields() {
       AccountInfo info = new AccountInfo(
           "uid-1", "user@example.com", "John Doe", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, "it",
+          "example.com", AccountStatus.active, false, false, false, "it",
           Map.of("carbonioFeatureFilesEnabled", true, "carbonioFeatureWscEnabled", false),
           Map.of("carbonioWscMaxGroupMembers", "50"),
           3_600_000L);
@@ -159,7 +174,7 @@ class UserServiceMappingTest {
     void mapsOnlyEnabledFeatures() {
       AccountInfo info = new AccountInfo(
           "uid-1", "user@example.com", "User", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, "en",
+          "example.com", AccountStatus.active, false, false, false, "en",
           Map.of("carbonioFeatureFilesEnabled", true, "carbonioFeatureWscEnabled", false),
           Map.of(), null);
 
@@ -172,7 +187,7 @@ class UserServiceMappingTest {
     void nullFeaturesBecomesEmptyList() {
       AccountInfo info = new AccountInfo(
           "uid-1", "user@example.com", "User", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, "en",
+          "example.com", AccountStatus.active, false, false, false, "en",
           null, Map.of(), null);
 
       UserMyself result = userService.mapAccountInfoToUserMyself(info);
@@ -184,7 +199,7 @@ class UserServiceMappingTest {
     void nullCapabilitiesBecomesEmptyMap() {
       AccountInfo info = new AccountInfo(
           "uid-1", "user@example.com", "User", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, "en",
+          "example.com", AccountStatus.active, false, false, false, "en",
           Map.of(), null, null);
 
       UserMyself result = userService.mapAccountInfoToUserMyself(info);
@@ -196,7 +211,7 @@ class UserServiceMappingTest {
     void mapsCapabilities() {
       AccountInfo info = new AccountInfo(
           "uid-1", "user@example.com", "User", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, "en",
+          "example.com", AccountStatus.active, false, false, false, "en",
           Map.of(),
           Map.of("carbonioWscMaxGroupMembers", "50", "carbonioFilesMaxUploadSize", "1048576"),
           null);
@@ -212,7 +227,7 @@ class UserServiceMappingTest {
     void nullLocaleDefaultsToEnglish() {
       AccountInfo info = new AccountInfo(
           "uid-1", "user@example.com", "User", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, null,
+          "example.com", AccountStatus.active, false, false, false, null,
           Map.of(), Map.of(), null);
 
       UserMyself result = userService.mapAccountInfoToUserMyself(info);
@@ -224,7 +239,7 @@ class UserServiceMappingTest {
     void mapsGuestType() {
       AccountInfo info = new AccountInfo(
           "uid-1", "guest@example.com", "Guest", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, true, "en",
+          "example.com", AccountStatus.active, false, false, true, "en",
           Map.of(), Map.of(), null);
 
       UserMyself result = userService.mapAccountInfoToUserMyself(info);
@@ -236,7 +251,7 @@ class UserServiceMappingTest {
     void nullStatusDefaultsToActive() {
       AccountInfo info = new AccountInfo(
           "uid-1", "user@example.com", "User", "cos-1", "dom-1",
-          "example.com", null, false, false, "en",
+          "example.com", null, false, false, false, "en",
           Map.of(), Map.of(), null);
 
       UserMyself result = userService.mapAccountInfoToUserMyself(info);

--- a/app/src/test/java/com/zextras/carbonio/user_management/service/UserServiceTest.java
+++ b/app/src/test/java/com/zextras/carbonio/user_management/service/UserServiceTest.java
@@ -65,7 +65,7 @@ class UserServiceTest {
 
   private AccountInfo sampleAccountInfo(String userId, String email) {
     return new AccountInfo(userId, email, "Test User", "cos-1", "dom-1",
-        "example.com", AccountStatus.active, false, false, "en",
+        "example.com", AccountStatus.active, false, false, false, "en",
         Map.of("carbonioFeatureFilesEnabled", true), Map.of(), 3_600_000L);
   }
 
@@ -123,7 +123,7 @@ class UserServiceTest {
 
       AccountInfo accountInfo = new AccountInfo(
           "user-1", "user@example.com", "John Doe", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, "en",
+          "example.com", AccountStatus.active, false, false, false, "en",
           Map.of("carbonioFeatureFilesEnabled", true), Map.of(), 3_600_000L);
       when(internalClient.getMyAccountInfo("token-1")).thenReturn(accountInfo);
       when(userMyselfCache.computeExpiresAt(anyLong())).thenReturn(futureExpiresAt());
@@ -164,7 +164,7 @@ class UserServiceTest {
     void bypassCache_skipsCacheRead_callsInternalApi() throws Exception {
       AccountInfo accountInfo = new AccountInfo(
           "user-1", "user@example.com", "John Doe", "cos-1", "dom-1",
-          "example.com", AccountStatus.active, false, false, "en",
+          "example.com", AccountStatus.active, false, false, false, "en",
           Map.of(), Map.of(), 3_600_000L);
       when(internalClient.getMyAccountInfo("token-1")).thenReturn(accountInfo);
       when(userMyselfCache.computeExpiresAt(anyLong())).thenReturn(futureExpiresAt());

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
     <!-- Dependencies -->
     <assertj.version>3.27.7</assertj.version>
-    <carbonio-mailbox-sdk.version>1.17.1</carbonio-mailbox-sdk.version>
+    <carbonio-mailbox-sdk.version>1.18.0</carbonio-mailbox-sdk.version>
     <carbonio-quarkus-extensions.version>1.8.2-1</carbonio-quarkus-extensions.version>
 
     <!-- Plugins -->


### PR DESCRIPTION
User Management derived the INTERNAL/GUEST user type from AccountInfo.isExternal, which mailbox computes from mail-transport routing rather than from the guest/virtual-account flag. Mailbox now exposes a dedicated isExternalVirtualAccount field (carbonio-mailbox #1075 / mailbox-sdk #101); read that instead. The public UserInfo/UserMyself contract is unchanged.

- bump carbonio-mailbox-sdk 1.17.1 -> 1.18.0
- UserService: map type from info.isExternalVirtualAccount()
- adapt AccountInfo constructor calls in tests to the new record component
- add regression test asserting isExternal no longer drives the type