### PR TITLE
fix(reuse): declare docs license centrally (header-less generated docs)

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -104,3 +104,9 @@ path = ".gitleaksignore"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
 SPDX-License-Identifier = "AGPL-3.0-only"
+
+[[annotations]]
+path = "**/docs/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Zextras <https://www.zextras.com>"
+SPDX-License-Identifier = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

- `app/docs/configs.md` is regenerated header-less by the carbonio-quarkus-extensions bootstrap at build time
- REUSE.toml lacked an annotation for it, causing `reuse lint` (verify-mode, fatal on devel) to fail
- Adds a scoped `**/docs/**` annotation with `precedence = aggregate`; pairs with dt3-pipeline lib excludes

## Changes

- `REUSE.toml` only — one new `[[annotations]]` block for `**/docs/**`

## Validation

Validated against `fsfe/reuse:5.0.2-debian` (exact CI image):
- `reuse lint` exits 0 with "Congratulations"
- No catch-all `**` glob added

## Test plan

- [ ] `reuse lint` passes in CI on devel
- [ ] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfwprkPZUWiomos3edfhRb

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XfwprkPZUWiomos3edfhRb