### PR TITLE
chore(deps): bump carbonio-quarkus-extensions to 1.11.0-1

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -1,8 +1,8 @@
 AGPL-3.0-only (https://spdx.org/licenses/AGPL-3.0-only.html) applies to:
 
-  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.8.2-1)
-  Carbonio Quarkus Extensions - gRPC SDK Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-grpc-sdk:1.8.2-1)
-  Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.8.2-1)
+  Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.11.0-1)
+  Carbonio Quarkus Extensions - gRPC SDK Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-grpc-sdk:1.11.0-1)
+  Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.11.0-1)
   Carbonio Systemd Notify (com.zextras.carbonio:carbonio-systemd-notify:1.0.1)
 
 Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html) applies to:

--- a/app/docs/configs.md
+++ b/app/docs/configs.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
-
-SPDX-License-Identifier: AGPL-3.0-only
--->
-
 # Default Configuration
 
 ## Networking Config

--- a/app/docs/openapi.yaml
+++ b/app/docs/openapi.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-only
-
 ---
 openapi: 3.1.0
 paths:

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- Dependencies -->
     <assertj.version>3.27.7</assertj.version>
     <carbonio-mailbox-sdk.version>1.18.0</carbonio-mailbox-sdk.version>
-    <carbonio-quarkus-extensions.version>1.8.2-1</carbonio-quarkus-extensions.version>
+    <carbonio-quarkus-extensions.version>1.11.0-1</carbonio-quarkus-extensions.version>
 
     <!-- Plugins -->
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>


### PR DESCRIPTION
## What
Bump `carbonio-quarkus-extensions` from **1.8.2-1** to **1.11.0-1** (latest release). Three-minor jump; watched for breaking changes (config prefixes, artifact renames, db-pool duration fix) — none affected this service.

## KV dotted-vs-slash check (no DB)
This service does **not** use the `-database` module, reads no `.../database/credentials/*` KV, and has **no** `carbonio-user-management-db` sibling repo. **No dotted-vs-slash concern.**

## Verification
Local build (Maven 3.9.15 / JDK 21): `mvn clean package -Drevision=1.2.1 -Dchangelist=-1` → **BUILD SUCCESS**, uber-jar produced, 1.11.0-1 (grpc-sdk/rest/bootstrap) resolved. Unit tests run explicitly (`-Dskip.unit.tests=false`): **104 passed, 0 failures**.

## Notes
CI Generated Files Sync may auto-commit regenerated docs (SPDX headers) — expected, non-fatal on PRs.