### PR TITLE
chore: group renovate patch/minor updates and disable dt3-pipeline bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,33 @@
   "extends": [
     "github>zextras/infra-renovate-config",
     "github>zextras/infra-renovate-config:java"
+  ],
+  "separateMultipleMajor": false,
+  "vulnerabilityAlerts": {
+    "groupName": null
+  },
+  "packageRules": [
+    {
+      "description": "Group all patch-level updates into a single PR",
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "groupName": "all patch updates"
+    },
+    {
+      "description": "Group all minor-level updates into a single PR",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "groupName": "all minor updates"
+    },
+    {
+      "description": "jenkins-lib-common is tracked on the dt3-pipeline branch on purpose; do not propose replacing the branch ref with a tag. The shared Jenkinsfile custom manager uses the github-tags datasource and treats @dt3-pipeline as a version. We will pin a tag manually once dt3-pipeline is merged.",
+      "matchPackageNames": [
+        "zextras/jenkins-lib-common"
+      ],
+      "matchCurrentValue": "/^dt3-pipeline$/",
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## What
Aligns this repo's `.github/renovate.json` with the shared convention used in `carbonio-quarkus-extensions`, **preserving the existing `extends` presets** of this repo.

## Behavior
- **Patch** updates → grouped into a single "all patch updates" PR
- **Minor** updates → grouped into a single "all minor updates" PR
- **Major** updates → remain individual PRs (not grouped)
- **Security / vulnerability** updates → ungrouped (`vulnerabilityAlerts.groupName: null`), so they open autonomously and immediately
- **jenkins-lib-common** → not bumped while pinned to the `dt3-pipeline` branch
- `separateMultipleMajor: false` to match the reference

The protobuf/gRPC rule from the extensions config is intentionally omitted — it is specific to the grpc-sdk code-generation toolchain and does not apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)