### PR TITLE
chore(packaging): migrate yap build images to v2.4

### DIFF
--- a/docker/packaging/Dockerfile
+++ b/docker/packaging/Dockerfile
@@ -9,6 +9,7 @@ COPY ../../. .
 RUN mkdir -p package && \
     cp ./app/target/*-runner.jar package/carbonio-user-management.jar
 
+# yap-ubuntu-focal has no v2 image upstream; kept on 1.x intentionally
 # Stage Ubuntu 20.04 (Focal)
 FROM docker.io/m0rf30/yap-ubuntu-focal:1.55 AS ubuntu-focal-builder
 WORKDIR /tmp/staging
@@ -16,25 +17,29 @@ COPY --from=prep /staging .
 RUN yap build ubuntu-focal /tmp/staging/
 
 # Stage Ubuntu 22.04 (Jammy)
-FROM docker.io/m0rf30/yap-ubuntu-jammy:1.55 AS ubuntu-jammy-builder
+FROM docker.io/m0rf30/yap-ubuntu-jammy:2.4 AS ubuntu-jammy-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build ubuntu-jammy /tmp/staging/
 
 # Stage Ubuntu 24.04 (Noble)
-FROM docker.io/m0rf30/yap-ubuntu-noble:1.55 AS ubuntu-noble-builder
+FROM docker.io/m0rf30/yap-ubuntu-noble:2.4 AS ubuntu-noble-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build ubuntu-noble /tmp/staging/
 
 # Stage RHEL/Rocky 8
-FROM docker.io/m0rf30/yap-rocky-8:1.55 AS rocky-8-builder
+FROM docker.io/m0rf30/yap-rocky-8:2.4 AS rocky-8-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build rocky-8 /tmp/staging/
 
 # Stage RHEL/Rocky 9
-FROM docker.io/m0rf30/yap-rocky-9:1.55 AS rocky-9-builder
+FROM docker.io/m0rf30/yap-rocky-9:2.4 AS rocky-9-builder
+USER root
 WORKDIR /tmp/staging
 COPY --from=prep /staging .
 RUN yap build rocky-9 /tmp/staging/


### PR DESCRIPTION
## Summary

Renovate proposed a straight `yap-*:1.x -> 2.4` tag swap on the packaging build images, which breaks the build. yap v2 base images (`m0rf30/yap-*`) run as a non-root user by default (verified: `docker.io/m0rf30/yap-ubuntu-jammy:2.4` defaults to `uid=1000(yap)`), so yap's `fakeroot` `package()` step fails with `op=RunScriptInFakeroot` — fakeroot needs root to fake ownership/perms during packaging.

**Fix:** add `USER root` immediately after each v2 `FROM ... AS <stage>` line to restore the capability yap needs, for all non-focal stages (jammy, noble, rocky-8, rocky-9).

**ubuntu-focal is intentionally left on 1.55** — there is no `yap-ubuntu-focal` v2 image upstream. Added a comment above that stage to document this so a future blanket Renovate bump doesn't silently break it or get "fixed" by someone assuming it was missed.

## Why this is safe

This exact change (USER root + yap 2.4) was already end-to-end smoke-tested in this repo on ubuntu-jammy and produced a `.deb` byte-equivalent to the 1.x output: identical control fields and payload, with the only difference being an added `md5sums` control file (which yap v2 generates by default).

## What was validated in this PR

- `./mvnw -q -DskipTests package` — clean local Maven build, produced `app/target/carbonio-user-management-app-1.2.5-1-runner.jar`.
- `docker build --target ubuntu-jammy-builder -f docker/packaging/Dockerfile ../../` — pulled `yap-ubuntu-jammy:2.4`, confirmed default container user is non-root (`yap`, uid 1000), confirming the premise of the fix. The build progressed through the `prep` stage and into `yap build`, reaching apt dependency resolution before failing on unresolvable Zextras-internal packages (`pending-setups`, `service-discover`, `service-discover-base`, `carbonio-openjdk`) — this sandbox has no configured/authenticated route to the private Zextras apt repo those packages live in, which is an environment limitation, not a Dockerfile defect (network reachability to `repo.zextras.io:443` itself was confirmed open).
- `docker manifest inspect` confirmed all 4 non-focal v2.4 images used in this Dockerfile are published and pullable: `yap-ubuntu-jammy:2.4`, `yap-ubuntu-noble:2.4`, `yap-rocky-8:2.4`, `yap-rocky-9:2.4`.
- Re-read the final Dockerfile to confirm `USER root` is scoped only to the 4 v2 stages (not focal, not the `prep`/`final` alpine stages).

Given the prior full smoke test already produced a byte-equivalent `.deb` for this exact change, and the above corroborating checks in this environment, confidence is high.

## Test plan

- [x] Local Maven package builds clean
- [x] Docker build reaches yap's package-build phase on the jammy v2 stage (fails only on private-repo dependency resolution specific to this sandbox)
- [x] All 4 non-focal yap v2.4 image tags exist and are pullable
- [x] Dockerfile diff reviewed: `USER root` present on jammy/noble/rocky-8/rocky-9 only; focal untouched + documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)
