### PR TITLE
chore(renovate): pin eclipse-temurin to JDK 21, block major bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,21 @@
       ],
       "matchCurrentValue": "/^dt3-pipeline$/",
       "enabled": false
+    },
+    {
+      "description": "Keep eclipse-temurin on JDK 21 (LTS). The app runs with java --enable-preview, which locks compiled bytecode to the exact JDK feature version; a base-image-only major bump breaks at runtime. Move JDK deliberately as an app-level project.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "eclipse-temurin",
+        "docker.io/library/eclipse-temurin"
+      ],
+      "matchCurrentValue": "/^21/",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a local Renovate `packageRule` that disables **major** version updates for the `eclipse-temurin` Docker base image while it is pinned to JDK 21 (`matchCurrentValue: "/^21/"`).
- The app runs with `java --enable-preview`, which locks compiled bytecode to the exact JDK feature version. A base-image-only major bump (e.g. temurin 21 → 25) would silently break the running service at startup, since the preview-compiled classes would no longer match the JVM's feature version.
- Minor/patch updates within JDK 21 are unaffected — only major bumps are blocked, and only while the current tag starts with `21`. Moving to a newer JDK stays a deliberate, reviewed, app-level decision.

## Test plan
- [x] `jq . .github/renovate.json` parses successfully
- [x] New `packageRules` entry follows the existing style/conventions in the file (matches the pattern already used for the `jenkins-lib-common` pin)
- [ ] Renovate dry-run / next scheduled run confirms major `eclipse-temurin` updates are suppressed while minor/patch updates continue to flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)