### PR TITLE
ci: pin jenkins-lib-common to v3.5.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,14 +24,6 @@
       "groupName": "all minor updates"
     },
     {
-      "description": "jenkins-lib-common is tracked on the dt3-pipeline branch on purpose; do not propose replacing the branch ref with a tag. The shared Jenkinsfile custom manager uses the github-tags datasource and treats @dt3-pipeline as a version. We will pin a tag manually once dt3-pipeline is merged.",
-      "matchPackageNames": [
-        "zextras/jenkins-lib-common"
-      ],
-      "matchCurrentValue": "/^dt3-pipeline$/",
-      "enabled": false
-    },
-    {
       "description": "Keep eclipse-temurin on JDK 21 (LTS). The app runs with java --enable-preview, which locks compiled bytecode to the exact JDK feature version; a base-image-only major bump breaks at runtime. Move JDK deliberately as an app-level project.",
       "matchDatasources": [
         "docker"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@dt3-pipeline',
+    identifier: 'jenkins-lib-common@v3.5.1',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Pin the `jenkins-lib-common` shared library to tag `v3.5.1` instead of tracking the `dt3-pipeline` branch, and remove the local renovate exception that pinned the branch ref (renovate can now manage the tag version normally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)