### PR TITLE
chore: bump carbonio-quarkus-extensions to 1.13.0-1

### DIFF
--- a/THIRDPARTIES
+++ b/THIRDPARTIES
@@ -3,8 +3,8 @@ List of third-party dependencies grouped by their license type.
 
     AGPL-3.0-only:
 
-        * Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.12.0-1 - no url defined)
-        * Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.12.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - Bootstrap Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-bootstrap:1.13.0-1 - no url defined)
+        * Carbonio Quarkus Extensions - REST Runtime (com.zextras.carbonio.quarkus:carbonio-quarkus-extensions-rest:1.13.0-1 - no url defined)
         * Carbonio Systemd Notify (com.zextras.carbonio:carbonio-systemd-notify:1.0.1 - https://github.com/zextras/carbonio-systemd-notify)
 
     Apache 2.0:

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <!-- Dependencies -->
     <assertj.version>3.27.7</assertj.version>
     <carbonio-mailbox-sdk.version>1.18.0</carbonio-mailbox-sdk.version>
-    <carbonio-quarkus-extensions.version>1.12.0-1</carbonio-quarkus-extensions.version>
+    <carbonio-quarkus-extensions.version>1.13.0-1</carbonio-quarkus-extensions.version>
 
     <!-- Plugins -->
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>


### PR DESCRIPTION
Bumps `carbonio-quarkus-extensions` from `1.12.0-1` to `1.13.0-1`.

- Property `carbonio-quarkus-extensions.version` in `pom.xml`.
- `THIRDPARTIES` regenerated via pre-commit (only the version reference changed).
- `mvn compile` green against 1.13.0-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)